### PR TITLE
Add RSS feed

### DIFF
--- a/.github/workflows/update-news.yml
+++ b/.github/workflows/update-news.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Fetch news and build site
         run: node scripts/fetch-news.js
       
+      - name: Generate RSS feed
+        run: node scripts/generate-rss.js
+      
       - name: Configure Git
         run: |
           git config user.name github-actions

--- a/package.json
+++ b/package.json
@@ -1,23 +1,25 @@
 {
-    "name": "cybersecurity-news-aggregator",
-    "version": "1.0.0",
-    "description": "Aggregates cybersecurity news from multiple sources",
-    "main": "index.js",
-    "scripts": {
-      "fetch": "node scripts/fetch-news.js",
-      "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "keywords": [
-      "cybersecurity",
-      "news",
-      "github-pages"
-    ],
-    "author": "",
-    "license": "MIT",
-    "dependencies": {
-      "axios": "^1.6.5",
-      "cheerio": "^1.0.0-rc.12",
-      "rss-parser": "^3.13.0",
-      "moment": "^2.30.1"
-    }
+  "name": "cybersecurity-news-aggregator",
+  "version": "1.0.0",
+  "description": "Aggregates cybersecurity news from multiple sources",
+  "main": "index.js",
+  "scripts": {
+    "fetch": "node scripts/fetch-news.js",
+    "generate-rss": "node scripts/generate-rss.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "cybersecurity",
+    "news",
+    "github-pages"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^1.6.5",
+    "cheerio": "^1.0.0-rc.12",
+    "rss-parser": "^3.13.0",
+    "moment": "^2.30.1",
+    "rss": "^1.2.2"
   }
+}

--- a/scripts/fetch-news.js
+++ b/scripts/fetch-news.js
@@ -136,6 +136,7 @@ function generateHTML(newsItems) {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cybersecurity News Aggregator</title>
   <meta name="description" content="Latest cybersecurity news from top sources">
+  <link rel="alternate" type="application/rss+xml" title="Cybersecurity News RSS Feed" href="./feed.xml" />
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -216,11 +217,20 @@ function generateHTML(newsItems) {
       color: #6c757d;
       font-size: 0.9rem;
     }
+    .rss-link {
+      display: inline-block;
+      margin-left: 10px;
+      vertical-align: middle;
+    }
+    .rss-link img {
+      height: 16px;
+      width: 16px;
+    }
   </style>
 </head>
 <body>
   <header>
-    <h1>Cybersecurity News Aggregator</h1>
+    <h1>Cybersecurity News Aggregator <a href="./feed.xml" class="rss-link" title="Subscribe to RSS feed"><img src="https://i.imgur.com/QxNpgm5.png" alt="RSS" /></a></h1>
     <p class="last-updated">Last updated: ${new Date().toLocaleString()}</p>
   </header>
   
@@ -241,7 +251,7 @@ function generateHTML(newsItems) {
   </div>
   
   <footer>
-    <p>Powered by GitHub Actions | Automatically updates every 3 hours</p>
+    <p>Powered by GitHub Actions | Automatically updates every 3 hours | <a href="./feed.xml">RSS Feed</a></p>
   </footer>
 </body>
 </html>

--- a/scripts/generate-rss.js
+++ b/scripts/generate-rss.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const RSS = require('rss');
+const moment = require('moment');
+
+// Path to the news data file
+const newsDataPath = path.join(__dirname, '../news-data.json');
+const rssOutputPath = path.join(__dirname, '../feed.xml');
+
+// Create RSS feed
+function generateRSSFeed() {
+  try {
+    // Read the news data from the JSON file
+    if (!fs.existsSync(newsDataPath)) {
+      console.error('News data file not found. Run fetch-news.js first.');
+      process.exit(1);
+    }
+
+    const newsData = JSON.parse(fs.readFileSync(newsDataPath, 'utf8'));
+    const configPath = path.join(__dirname, '../config/news-sources.json');
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    
+    // Create a new RSS feed
+    const feed = new RSS({
+      title: 'Cybersecurity News Aggregator',
+      description: 'Latest cybersecurity news from top sources',
+      feed_url: 'https://ricomanifesto.github.io/SentryDigest/feed.xml',
+      site_url: 'https://ricomanifesto.github.io/SentryDigest/',
+      image_url: 'https://ricomanifesto.github.io/SentryDigest/icon.png',
+      language: 'en',
+      pubDate: new Date(),
+      ttl: '180', // Time to live in minutes (3 hours)
+      custom_namespaces: {
+        'dc': 'http://purl.org/dc/elements/1.1/'
+      }
+    });
+
+    // Add information about the sources
+    const activeSources = config.sources
+      .filter(source => source.enabled)
+      .map(source => source.name)
+      .join(', ');
+    
+    feed.custom_elements.push(
+      {'comment': `News aggregated from: ${activeSources}`}
+    );
+
+    // Add items to the feed
+    newsData.forEach(item => {
+      feed.item({
+        title: item.title,
+        description: item.summary || 'No summary available',
+        url: item.link,
+        guid: item.link,
+        categories: [item.source],
+        author: item.source,
+        date: item.date,
+        custom_elements: [
+          {'dc:source': item.source},
+          {'dc:date': moment(item.date).format('YYYY-MM-DD')}
+        ]
+      });
+    });
+
+    // Generate the XML and write to file
+    const xml = feed.xml({ indent: true });
+    fs.writeFileSync(rssOutputPath, xml);
+    console.log(`Generated RSS feed at ${rssOutputPath}`);
+
+    // Create a JSON file with RSS feed information (for reference)
+    const feedInfo = {
+      title: 'Cybersecurity News Aggregator RSS Feed',
+      url: 'https://ricomanifesto.github.io/SentryDigest/feed.xml',
+      itemCount: newsData.length,
+      sources: activeSources.split(', '),
+      lastUpdated: new Date().toISOString()
+    };
+
+    fs.writeFileSync(
+      path.join(__dirname, '../feed-info.json'),
+      JSON.stringify(feedInfo, null, 2)
+    );
+    console.log('Generated feed-info.json');
+
+  } catch (error) {
+    console.error('Error generating RSS feed:', error.message);
+    process.exit(1);
+  }
+}
+
+generateRSSFeed();


### PR DESCRIPTION
This PR adds RSS feed functionality to the Cybersecurity News Aggregator:

- Adds a new RSS generation script that creates a standards-compliant RSS feed
- Updates the HTML to include links to the RSS feed
- Updates the GitHub workflow to generate the RSS feed
- Adds the necessary RSS package dependency

The RSS feed will be available at /feed.xml and will update automatically with the site every 3 hours.