### PR TITLE
Add generated artifact validation gate

### DIFF
--- a/.github/workflows/update-news.yml
+++ b/.github/workflows/update-news.yml
@@ -30,6 +30,9 @@ jobs:
       
       - name: Generate RSS feed
         run: node scripts/generate-rss.js
+
+      - name: Validate generated artifacts
+        run: npm test
       
       - name: Configure Git
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,26 @@ Thumbs.db
 
 # Private docs
 docs/notes/
+
+# Private local files
+AGENTS.md
+agents.md
+AGENT.md
+agent.md
+CLAUDE.md
+claude.md
+GEMINI.md
+gemini.md
+.claude/
+.codex/
+.copilot/
+.cursor/
+.cursorrules
+.windsurf/
+.windsurfrules
+.github/copilot-instructions.md
+.github/instructions/
+agent-instructions.md
+agent_instructions.md
+assistant-instructions.md
+assistant_instructions.md

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Manual run:
 ```bash
 npm run fetch          # Fetch news, generate HTML
 npm run generate-rss    # Generate RSS feed
+npm test               # Validate generated artifacts
 ```
 
 ## Configuration
@@ -63,3 +64,12 @@ Updates trigger [SentryInsight](https://github.com/ricomanifesto/SentryInsight) 
 - `feed.xml` - RSS feed
 - `news-data.json` - Raw data
 - `feed-info.json` - Metadata
+
+## Validation
+
+`npm test` runs the Node test suite and then performs a dependency-free artifact
+validation check. The artifact validator verifies that the source config,
+`news-data.json`, `feed.xml`, `feed-info.json`, and `index.html` have matching
+item counts, valid dates/URLs, enabled source names, and newest-first news
+ordering. The GitHub Actions update workflow runs this check before committing
+generated artifacts or dispatching downstream analysis.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "fetch": "node scripts/fetch-news.js",
     "generate-rss": "node scripts/generate-rss.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "validate": "node scripts/validate-artifacts.js",
+    "test": "node --test && npm run validate"
   },
   "keywords": [
     "cybersecurity",

--- a/scripts/validate-artifacts.js
+++ b/scripts/validate-artifacts.js
@@ -1,0 +1,223 @@
+const fs = require('fs');
+const path = require('path');
+
+function readText(label, filePath, repoRoot, failures) {
+  if (!fs.existsSync(filePath)) {
+    fail(failures, `${label} is missing at ${path.relative(repoRoot, filePath)}`);
+    return null;
+  }
+
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function fail(failures, message) {
+  failures.push(message);
+}
+
+function readJson(label, filePath, repoRoot, failures) {
+  const text = readText(label, filePath, repoRoot, failures);
+  if (text === null) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    fail(failures, `${label} is not valid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function isValidHttpUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isValidDate(value) {
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime());
+}
+
+function countMatches(text, pattern) {
+  return (text.match(pattern) || []).length;
+}
+
+function validateArtifacts(repoRoot = path.join(__dirname, '..')) {
+  const artifacts = {
+    config: path.join(repoRoot, 'config/news-sources.json'),
+    newsData: path.join(repoRoot, 'news-data.json'),
+    feedInfo: path.join(repoRoot, 'feed-info.json'),
+    feedXml: path.join(repoRoot, 'feed.xml'),
+    indexHtml: path.join(repoRoot, 'index.html'),
+  };
+  const failures = [];
+  const config = readJson('config/news-sources.json', artifacts.config, repoRoot, failures);
+  const newsData = readJson('news-data.json', artifacts.newsData, repoRoot, failures);
+  const feedInfo = readJson('feed-info.json', artifacts.feedInfo, repoRoot, failures);
+  const feedXml = readText('feed.xml', artifacts.feedXml, repoRoot, failures);
+  const indexHtml = readText('index.html', artifacts.indexHtml, repoRoot, failures);
+
+  let enabledSources = [];
+  let maxNewsItems = 30;
+
+  if (config) {
+    if (!Array.isArray(config.sources) || config.sources.length === 0) {
+      fail(failures, 'config/news-sources.json must define at least one source');
+    } else {
+      enabledSources = config.sources.filter((source) => source.enabled);
+      enabledSources.forEach((source, index) => {
+        const label = `config source ${index + 1}`;
+        if (!source.name || typeof source.name !== 'string') {
+          fail(failures, `${label} must have a string name`);
+        }
+        if (!source.url || !isValidHttpUrl(source.url)) {
+          fail(failures, `${label} must have an http(s) url`);
+        }
+        if (source.type !== 'rss') {
+          fail(failures, `${label} has unsupported type "${source.type}"`);
+        }
+      });
+    }
+
+    if (config.settings && config.settings.maxNewsItems !== undefined) {
+      maxNewsItems = config.settings.maxNewsItems;
+    }
+
+    if (!Number.isInteger(maxNewsItems) || maxNewsItems <= 0) {
+      fail(failures, 'settings.maxNewsItems must be a positive integer');
+    }
+  }
+
+  if (newsData) {
+    if (!Array.isArray(newsData)) {
+      fail(failures, 'news-data.json must be an array');
+    } else {
+      if (newsData.length > maxNewsItems) {
+        fail(failures, `news-data.json has ${newsData.length} items, which exceeds maxNewsItems ${maxNewsItems}`);
+      }
+
+      const links = new Set();
+      const enabledSourceNames = new Set(enabledSources.map((source) => source.name));
+
+      newsData.forEach((item, index) => {
+        const label = `news-data item ${index + 1}`;
+        if (!item || typeof item !== 'object' || Array.isArray(item)) {
+          fail(failures, `${label} must be an object`);
+          return;
+        }
+
+        if (!item.title || typeof item.title !== 'string') {
+          fail(failures, `${label} must have a string title`);
+        }
+        if (!item.link || !isValidHttpUrl(item.link)) {
+          fail(failures, `${label} must have an http(s) link`);
+        } else if (links.has(item.link)) {
+          fail(failures, `${label} duplicates link ${item.link}`);
+        } else {
+          links.add(item.link);
+        }
+        if (!item.date || !isValidDate(item.date)) {
+          fail(failures, `${label} must have a valid date`);
+        }
+        if (!item.source || typeof item.source !== 'string') {
+          fail(failures, `${label} must have a string source`);
+        } else if (enabledSourceNames.size > 0 && !enabledSourceNames.has(item.source)) {
+          fail(failures, `${label} source "${item.source}" is not enabled in config`);
+        }
+        if (item.summary !== undefined && typeof item.summary !== 'string') {
+          fail(failures, `${label} summary must be a string when present`);
+        }
+
+        if (index > 0 && isValidDate(item.date) && isValidDate(newsData[index - 1].date)) {
+          const previous = new Date(newsData[index - 1].date).getTime();
+          const current = new Date(item.date).getTime();
+          if (current > previous) {
+            fail(failures, `${label} is newer than the previous item; news-data.json must be newest-first`);
+          }
+        }
+      });
+    }
+  }
+
+  if (feedInfo && newsData && Array.isArray(newsData)) {
+    if (feedInfo.itemCount !== newsData.length) {
+      fail(failures, `feed-info.json itemCount ${feedInfo.itemCount} does not match news-data.json length ${newsData.length}`);
+    }
+
+    if (!Array.isArray(feedInfo.sources)) {
+      fail(failures, 'feed-info.json sources must be an array');
+    } else {
+      const expectedSources = enabledSources.map((source) => source.name).sort();
+      const actualSources = [...feedInfo.sources].sort();
+      if (JSON.stringify(actualSources) !== JSON.stringify(expectedSources)) {
+        fail(failures, 'feed-info.json sources must match enabled config sources');
+      }
+    }
+
+    if (!feedInfo.lastUpdated || !isValidDate(feedInfo.lastUpdated)) {
+      fail(failures, 'feed-info.json lastUpdated must be a valid date');
+    }
+  }
+
+  if (feedXml && newsData && Array.isArray(newsData)) {
+    if (!feedXml.includes('<rss') || !feedXml.includes('<channel>')) {
+      fail(failures, 'feed.xml must contain an RSS channel');
+    }
+
+    const feedItemCount = countMatches(feedXml, /<item>/g);
+    if (feedItemCount !== newsData.length) {
+      fail(failures, `feed.xml has ${feedItemCount} items, expected ${newsData.length}`);
+    }
+
+    if (!feedXml.includes('https://ricomanifesto.github.io/SentryDigest/feed.xml')) {
+      fail(failures, 'feed.xml must advertise the public SentryDigest feed URL');
+    }
+  }
+
+  if (indexHtml && newsData && Array.isArray(newsData)) {
+    if (!indexHtml.includes('SentryDigest')) {
+      fail(failures, 'index.html must identify SentryDigest');
+    }
+    if (!indexHtml.includes('href="./feed.xml"')) {
+      fail(failures, 'index.html must link to feed.xml');
+    }
+
+    const articleCount = countMatches(indexHtml, /<article class="news-item"/g);
+    if (newsData.length > 0 && articleCount !== newsData.length) {
+      fail(failures, `index.html renders ${articleCount} article cards, expected ${newsData.length}`);
+    }
+  }
+
+  const itemCount = Array.isArray(newsData) ? newsData.length : 0;
+
+  return {
+    valid: failures.length === 0,
+    failures,
+    itemCount,
+    enabledSourceCount: enabledSources.length,
+  };
+}
+
+function runCli() {
+  const result = validateArtifacts();
+
+  if (!result.valid) {
+    console.error('Artifact validation failed:');
+    result.failures.forEach((failure) => console.error(`- ${failure}`));
+    process.exit(1);
+  }
+
+  console.log(`Artifact validation passed for ${result.itemCount} news items across ${result.enabledSourceCount} enabled sources.`);
+}
+
+if (require.main === module) {
+  runCli();
+}
+
+module.exports = {
+  validateArtifacts,
+};

--- a/test/validate-artifacts.test.js
+++ b/test/validate-artifacts.test.js
@@ -1,0 +1,151 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { validateArtifacts } = require('../scripts/validate-artifacts');
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+function writeText(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, value);
+}
+
+function createFixture(overrides = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sentrydigest-'));
+  const newsData = overrides.newsData || [
+    {
+      title: 'Newer item',
+      link: 'https://example.com/newer',
+      date: '2026-06-17T18:00:00.000Z',
+      source: 'Example Security',
+      summary: 'Newest story',
+    },
+    {
+      title: 'Older item',
+      link: 'https://example.com/older',
+      date: '2026-06-17T17:00:00.000Z',
+      source: 'Example Security',
+      summary: 'Older story',
+    },
+  ];
+
+  writeJson(path.join(repoRoot, 'config/news-sources.json'), {
+    sources: [
+      {
+        name: 'Example Security',
+        url: 'https://example.com/feed.xml',
+        type: 'rss',
+        enabled: true,
+      },
+    ],
+    settings: {
+      maxNewsItems: 30,
+    },
+  });
+  writeJson(path.join(repoRoot, 'news-data.json'), newsData);
+  writeJson(path.join(repoRoot, 'feed-info.json'), {
+    title: 'Cybersecurity News Aggregator RSS Feed',
+    url: 'https://ricomanifesto.github.io/SentryDigest/feed.xml',
+    itemCount: overrides.feedInfoItemCount ?? newsData.length,
+    sources: ['Example Security'],
+    lastUpdated: '2026-06-17T18:30:00.000Z',
+  });
+  writeText(
+    path.join(repoRoot, 'feed.xml'),
+    overrides.feedXml ||
+      `<?xml version="1.0" encoding="UTF-8"?><rss><channel>
+        <atom:link href="https://ricomanifesto.github.io/SentryDigest/feed.xml" />
+        ${newsData.map((item) => `<item><title>${item.title}</title></item>`).join('\n')}
+      </channel></rss>`
+  );
+  writeText(
+    path.join(repoRoot, 'index.html'),
+    overrides.indexHtml ||
+      `<html><body>
+        <h1>SentryDigest</h1>
+        <a href="./feed.xml">RSS</a>
+        ${newsData.map((item) => `<article class="news-item">${item.title}</article>`).join('\n')}
+      </body></html>`
+  );
+
+  return repoRoot;
+}
+
+test('validateArtifacts passes when generated artifacts agree', () => {
+  const repoRoot = createFixture();
+
+  const result = validateArtifacts(repoRoot);
+
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.itemCount, 2);
+  assert.equal(result.enabledSourceCount, 1);
+});
+
+test('validateArtifacts reports every changed downstream artifact mismatch', () => {
+  const repoRoot = createFixture({
+    feedInfoItemCount: 1,
+    feedXml: `<?xml version="1.0" encoding="UTF-8"?><rss><channel>
+      <atom:link href="https://ricomanifesto.github.io/SentryDigest/feed.xml" />
+      <item><title>Only one item</title></item>
+    </channel></rss>`,
+    indexHtml: `<html><body>
+      <h1>SentryDigest</h1>
+      <a href="./feed.xml">RSS</a>
+      <article class="news-item">Only one item</article>
+    </body></html>`,
+  });
+
+  const result = validateArtifacts(repoRoot);
+
+  assert.equal(result.valid, false);
+  assert.match(
+    result.failures.join('\n'),
+    /feed-info\.json itemCount 1 does not match news-data\.json length 2/
+  );
+  assert.match(result.failures.join('\n'), /feed\.xml has 1 items, expected 2/);
+  assert.match(result.failures.join('\n'), /index\.html renders 1 article cards, expected 2/);
+});
+
+test('validateArtifacts reports missing generated artifacts', () => {
+  const repoRoot = createFixture();
+  fs.rmSync(path.join(repoRoot, 'feed.xml'));
+
+  const result = validateArtifacts(repoRoot);
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /feed\.xml is missing/);
+});
+
+test('validateArtifacts rejects duplicate links and non-newest-first data', () => {
+  const repoRoot = createFixture({
+    newsData: [
+      {
+        title: 'Older duplicate',
+        link: 'https://example.com/duplicate',
+        date: '2026-06-17T17:00:00.000Z',
+        source: 'Example Security',
+        summary: 'Older duplicate story',
+      },
+      {
+        title: 'Newer duplicate',
+        link: 'https://example.com/duplicate',
+        date: '2026-06-17T18:00:00.000Z',
+        source: 'Example Security',
+        summary: 'Newer duplicate story',
+      },
+    ],
+  });
+
+  const result = validateArtifacts(repoRoot);
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /duplicates link https:\/\/example\.com\/duplicate/);
+  assert.match(result.failures.join('\n'), /must be newest-first/);
+});


### PR DESCRIPTION
## Summary
- Add a Node validation script for generated news artifacts.
- Cover matching item counts, source names, dates, URLs, RSS output, HTML output, duplicates, missing files, and sort order.
- Run the validation gate in the update workflow before commits and downstream dispatch.

## Motivation
Generated feed files can drift from source data when one output updates without the others. The new gate blocks mismatched artifacts before publication.

## Validation
- `npm test`