### PR TITLE
Add JavaScript syntax validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Updates trigger [SentryInsight](https://github.com/ricomanifesto/SentryInsight) 
 
 ## Validation
 
-`npm test` runs the Node test suite and then performs a dependency-free artifact
-validation check. The artifact validator verifies that the source config,
-`news-data.json`, `feed.xml`, `feed-info.json`, and `index.html` have matching
-item counts, valid dates/URLs, enabled source names, and newest-first news
-ordering. The GitHub Actions update workflow runs this check before committing
-generated artifacts or dispatching downstream analysis.
+`npm test` runs the Node test suite, checks JavaScript syntax, and then performs
+a dependency-free artifact validation check. The artifact validator verifies
+that the source config, `news-data.json`, `feed.xml`, `feed-info.json`, and
+`index.html` have matching item counts, valid dates/URLs, enabled source names,
+and newest-first news ordering. The GitHub Actions update workflow runs this
+check before committing generated artifacts or dispatching downstream analysis.

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "fetch": "node scripts/fetch-news.js",
     "generate-rss": "node scripts/generate-rss.js",
+    "syntax": "node scripts/check-js-syntax.js",
     "validate": "node scripts/validate-artifacts.js",
-    "test": "node --test && npm run validate"
+    "test": "node --test && npm run syntax && npm run validate"
   },
   "keywords": [
     "cybersecurity",

--- a/scripts/check-js-syntax.js
+++ b/scripts/check-js-syntax.js
@@ -1,0 +1,83 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_DIRS = ['scripts', 'test'];
+const JS_EXTENSIONS = new Set(['.js', '.mjs', '.cjs']);
+
+function toRelativePath(repoRoot, filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join('/');
+}
+
+function listJavaScriptFiles(repoRoot, dirs = DEFAULT_DIRS) {
+  const files = [];
+
+  function visit(entryPath) {
+    if (!fs.existsSync(entryPath)) {
+      return;
+    }
+
+    const stat = fs.statSync(entryPath);
+    if (stat.isDirectory()) {
+      fs.readdirSync(entryPath)
+        .sort()
+        .forEach((entry) => visit(path.join(entryPath, entry)));
+      return;
+    }
+
+    if (stat.isFile() && JS_EXTENSIONS.has(path.extname(entryPath))) {
+      files.push(entryPath);
+    }
+  }
+
+  dirs.forEach((dir) => visit(path.join(repoRoot, dir)));
+  return files.sort((a, b) => toRelativePath(repoRoot, a).localeCompare(toRelativePath(repoRoot, b)));
+}
+
+function checkJavaScriptSyntax({ repoRoot = path.join(__dirname, '..'), files } = {}) {
+  const targets = files || listJavaScriptFiles(repoRoot);
+  const checkedFiles = [];
+  const failures = [];
+
+  targets.forEach((filePath) => {
+    const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(repoRoot, filePath);
+    const relativePath = toRelativePath(repoRoot, absolutePath);
+    checkedFiles.push(relativePath);
+
+    const result = spawnSync(process.execPath, ['--check', absolutePath], {
+      encoding: 'utf8',
+    });
+
+    if (result.status !== 0) {
+      const details = (result.stderr || result.stdout || '').trim();
+      failures.push(`${relativePath}: ${details}`);
+    }
+  });
+
+  return {
+    valid: failures.length === 0,
+    failures,
+    checkedFiles,
+  };
+}
+
+function runCli() {
+  const result = checkJavaScriptSyntax();
+
+  if (!result.valid) {
+    console.error('JavaScript syntax check failed:');
+    result.failures.forEach((failure) => console.error(`- ${failure}`));
+    process.exit(1);
+  }
+
+  console.log(`JavaScript syntax check passed for ${result.checkedFiles.length} files.`);
+}
+
+if (require.main === module) {
+  runCli();
+}
+
+module.exports = {
+  checkJavaScriptSyntax,
+  listJavaScriptFiles,
+};

--- a/test/check-js-syntax.test.js
+++ b/test/check-js-syntax.test.js
@@ -1,0 +1,36 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { checkJavaScriptSyntax } = require('../scripts/check-js-syntax');
+
+function createTempFile(name, contents) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sentrydigest-js-'));
+  const filePath = path.join(repoRoot, name);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+  return { repoRoot, filePath };
+}
+
+test('checkJavaScriptSyntax passes valid JavaScript files', () => {
+  const { repoRoot, filePath } = createTempFile('scripts/valid.js', 'const answer = 42;\n');
+
+  const result = checkJavaScriptSyntax({ repoRoot, files: [filePath] });
+
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.checkedFiles, ['scripts/valid.js']);
+});
+
+test('checkJavaScriptSyntax reports invalid JavaScript files', () => {
+  const { repoRoot, filePath } = createTempFile('scripts/invalid.js', 'function broken( {\n');
+
+  const result = checkJavaScriptSyntax({ repoRoot, files: [filePath] });
+
+  assert.equal(result.valid, false);
+  assert.equal(result.checkedFiles.length, 1);
+  assert.match(result.failures.join('\n'), /scripts\/invalid\.js/);
+  assert.match(result.failures.join('\n'), /SyntaxError/);
+});


### PR DESCRIPTION
## Summary
- Add a dependency-free JavaScript syntax check for repo scripts and tests.
- Wire the syntax check into npm test before artifact validation.
- Add tests for valid and invalid JavaScript inputs.

## Validation
- npm test