### PR TITLE
Validate generated article links

### DIFF
--- a/scripts/validate-artifacts.js
+++ b/scripts/validate-artifacts.js
@@ -46,6 +46,55 @@ function countMatches(text, pattern) {
   return (text.match(pattern) || []).length;
 }
 
+function decodeCodePoint(value, radix) {
+  const codePoint = Number.parseInt(value, radix);
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+    return null;
+  }
+
+  return String.fromCodePoint(codePoint);
+}
+
+function decodeHtmlEntities(value) {
+  return String(value)
+    .replace(/&#x([0-9a-f]+);?/gi, (entity, hex) => decodeCodePoint(hex, 16) ?? entity)
+    .replace(/&#([0-9]+);?/g, (entity, decimal) => decodeCodePoint(decimal, 10) ?? entity)
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function isSafeGeneratedArticleHref(value) {
+  const href = decodeHtmlEntities(value).trim();
+  if (href === '#') {
+    return true;
+  }
+
+  try {
+    const url = new URL(href);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function extractArticleHrefs(indexHtml) {
+  const hrefs = [];
+  const articlePattern = /<article\b[^>]*class="[^"]*\bnews-item\b[^"]*"[^>]*>[\s\S]*?<\/article>/gi;
+  const hrefPattern = /\bhref\s*=\s*"([^"]*)"/gi;
+  let articleMatch;
+
+  while ((articleMatch = articlePattern.exec(indexHtml)) !== null) {
+    let hrefMatch;
+    while ((hrefMatch = hrefPattern.exec(articleMatch[0])) !== null) {
+      hrefs.push(hrefMatch[1]);
+    }
+  }
+
+  return hrefs;
+}
+
 function validateArtifacts(repoRoot = path.join(__dirname, '..')) {
   const artifacts = {
     config: path.join(repoRoot, 'config/news-sources.json'),
@@ -190,6 +239,12 @@ function validateArtifacts(repoRoot = path.join(__dirname, '..')) {
     if (newsData.length > 0 && articleCount !== newsData.length) {
       fail(failures, `index.html renders ${articleCount} article cards, expected ${newsData.length}`);
     }
+
+    extractArticleHrefs(indexHtml).forEach((href) => {
+      if (!isSafeGeneratedArticleHref(href)) {
+        fail(failures, `index.html contains unsafe article href ${decodeHtmlEntities(href)}`);
+      }
+    });
   }
 
   const itemCount = Array.isArray(newsData) ? newsData.length : 0;
@@ -219,5 +274,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  extractArticleHrefs,
+  isSafeGeneratedArticleHref,
   validateArtifacts,
 };

--- a/test/validate-artifacts.test.js
+++ b/test/validate-artifacts.test.js
@@ -149,3 +149,36 @@ test('validateArtifacts rejects duplicate links and non-newest-first data', () =
   assert.match(result.failures.join('\n'), /duplicates link https:\/\/example\.com\/duplicate/);
   assert.match(result.failures.join('\n'), /must be newest-first/);
 });
+
+test('validateArtifacts rejects unsafe article links in generated HTML', () => {
+  const repoRoot = createFixture({
+    indexHtml: `<html><body>
+      <h1>SentryDigest</h1>
+      <a href="./feed.xml">RSS</a>
+      <article class="news-item"><a href="javascript:alert(1)">Unsafe</a></article>
+      <article class="news-item"><a href="https://example.com/older">Older</a></article>
+    </body></html>`,
+  });
+
+  const result = validateArtifacts(repoRoot);
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /index\.html contains unsafe article href javascript:alert\(1\)/);
+});
+
+test('validateArtifacts reports malformed encoded article hrefs without throwing', () => {
+  const repoRoot = createFixture({
+    indexHtml: `<html><body>
+      <h1>SentryDigest</h1>
+      <a href="./feed.xml">RSS</a>
+      <article class="news-item"><a href="&#9999999999;">Malformed</a></article>
+      <article class="news-item"><a href="https://example.com/older">Older</a></article>
+    </body></html>`,
+  });
+
+  assert.doesNotThrow(() => validateArtifacts(repoRoot));
+
+  const result = validateArtifacts(repoRoot);
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /index\.html contains unsafe article href/);
+});


### PR DESCRIPTION
## Summary
- Validate article hrefs in generated HTML artifacts.
- Allow only inert anchors or HTTP(S) links inside article cards.
- Add regression coverage for unsafe and malformed encoded hrefs.

## Validation
- npm test