### PR TITLE
Validate single-quoted article links

### DIFF
--- a/scripts/validate-artifacts.js
+++ b/scripts/validate-artifacts.js
@@ -82,13 +82,13 @@ function isSafeGeneratedArticleHref(value) {
 function extractArticleHrefs(indexHtml) {
   const hrefs = [];
   const articlePattern = /<article\b[^>]*class="[^"]*\bnews-item\b[^"]*"[^>]*>[\s\S]*?<\/article>/gi;
-  const hrefPattern = /\bhref\s*=\s*"([^"]*)"/gi;
+  const hrefPattern = /\bhref\s*=\s*(["'])(.*?)\1/gi;
   let articleMatch;
 
   while ((articleMatch = articlePattern.exec(indexHtml)) !== null) {
     let hrefMatch;
     while ((hrefMatch = hrefPattern.exec(articleMatch[0])) !== null) {
-      hrefs.push(hrefMatch[1]);
+      hrefs.push(hrefMatch[2]);
     }
   }
 

--- a/test/validate-artifacts.test.js
+++ b/test/validate-artifacts.test.js
@@ -166,6 +166,22 @@ test('validateArtifacts rejects unsafe article links in generated HTML', () => {
   assert.match(result.failures.join('\n'), /index\.html contains unsafe article href javascript:alert\(1\)/);
 });
 
+test('validateArtifacts rejects single-quoted unsafe article links in generated HTML', () => {
+  const repoRoot = createFixture({
+    indexHtml: `<html><body>
+      <h1>SentryDigest</h1>
+      <a href="./feed.xml">RSS</a>
+      <article class="news-item"><a href='javascript:alert(1)'>Unsafe</a></article>
+      <article class="news-item"><a href="https://example.com/older">Older</a></article>
+    </body></html>`,
+  });
+
+  const result = validateArtifacts(repoRoot);
+
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /index\.html contains unsafe article href javascript:alert\(1\)/);
+});
+
 test('validateArtifacts reports malformed encoded article hrefs without throwing', () => {
   const repoRoot = createFixture({
     indexHtml: `<html><body>


### PR DESCRIPTION
## Summary
- Detect single-quoted href attributes inside generated article cards.
- Keep unsafe generated article links blocked during artifact validation.
- Add regression coverage for single-quoted unsafe hrefs.

## Validation
- npm test