### PR TITLE
Validate generated article links

### DIFF
--- a/scripts/validate-artifacts.js
+++ b/scripts/validate-artifacts.js
@@ -95,6 +95,34 @@ function extractArticleHrefs(indexHtml) {
   return hrefs;
 }
 
+function extractFeedItemLinks(feedXml) {
+  const links = [];
+  const itemPattern = /<item\b[^>]*>[\s\S]*?<\/item>/gi;
+  const linkPattern = /<link\b[^>]*>([\s\S]*?)<\/link>/i;
+  let itemMatch;
+
+  while ((itemMatch = itemPattern.exec(feedXml)) !== null) {
+    const linkMatch = linkPattern.exec(itemMatch[0]);
+    links.push(linkMatch ? decodeHtmlEntities(linkMatch[1].trim()) : '');
+  }
+
+  return links;
+}
+
+function assertLinksMatchNewsData(label, actualLinks, newsData, failures, linkLabel = 'link') {
+  if (actualLinks.length !== newsData.length) {
+    fail(failures, `${label} has ${actualLinks.length} article links, expected ${newsData.length}`);
+    return;
+  }
+
+  actualLinks.forEach((actualLink, index) => {
+    const expectedLink = newsData[index].link;
+    if (actualLink !== expectedLink) {
+      fail(failures, `${label} item ${index + 1} ${linkLabel} ${actualLink} does not match news-data.json link ${expectedLink}`);
+    }
+  });
+}
+
 function validateArtifacts(repoRoot = path.join(__dirname, '..')) {
   const artifacts = {
     config: path.join(repoRoot, 'config/news-sources.json'),
@@ -222,6 +250,8 @@ function validateArtifacts(repoRoot = path.join(__dirname, '..')) {
       fail(failures, `feed.xml has ${feedItemCount} items, expected ${newsData.length}`);
     }
 
+    assertLinksMatchNewsData('feed.xml', extractFeedItemLinks(feedXml), newsData, failures);
+
     if (!feedXml.includes('https://ricomanifesto.github.io/SentryDigest/feed.xml')) {
       fail(failures, 'feed.xml must advertise the public SentryDigest feed URL');
     }
@@ -245,6 +275,8 @@ function validateArtifacts(repoRoot = path.join(__dirname, '..')) {
         fail(failures, `index.html contains unsafe article href ${decodeHtmlEntities(href)}`);
       }
     });
+
+    assertLinksMatchNewsData('index.html article', extractArticleHrefs(indexHtml), newsData, failures, 'href');
   }
 
   const itemCount = Array.isArray(newsData) ? newsData.length : 0;
@@ -274,6 +306,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  extractFeedItemLinks,
   extractArticleHrefs,
   isSafeGeneratedArticleHref,
   validateArtifacts,

--- a/scripts/validate-artifacts.js
+++ b/scripts/validate-artifacts.js
@@ -122,9 +122,8 @@ function assertLinksMatchNewsData(label, actualLinks, newsData, failures, linkLa
     }
 
     const expectedLink = article.link;
-    const decodedLink = decodeHtmlEntities(actualLink);
-    if (decodedLink !== expectedLink) {
-      fail(failures, `${label} item ${index + 1} ${linkLabel} ${decodedLink} does not match news-data.json link ${expectedLink}`);
+    if (actualLink !== expectedLink) {
+      fail(failures, `${label} item ${index + 1} ${linkLabel} ${actualLink} does not match news-data.json link ${expectedLink}`);
     }
   });
 }
@@ -276,13 +275,20 @@ function validateArtifacts(repoRoot = path.join(__dirname, '..')) {
       fail(failures, `index.html renders ${articleCount} article cards, expected ${newsData.length}`);
     }
 
-    extractArticleHrefs(indexHtml).forEach((href) => {
+    const articleHrefs = extractArticleHrefs(indexHtml);
+    articleHrefs.forEach((href) => {
       if (!isSafeGeneratedArticleHref(href)) {
         fail(failures, `index.html contains unsafe article href ${decodeHtmlEntities(href)}`);
       }
     });
 
-    assertLinksMatchNewsData('index.html article', extractArticleHrefs(indexHtml), newsData, failures, 'href');
+    assertLinksMatchNewsData(
+      'index.html article',
+      articleHrefs.map(decodeHtmlEntities),
+      newsData,
+      failures,
+      'href'
+    );
   }
 
   const itemCount = Array.isArray(newsData) ? newsData.length : 0;

--- a/scripts/validate-artifacts.js
+++ b/scripts/validate-artifacts.js
@@ -116,9 +116,15 @@ function assertLinksMatchNewsData(label, actualLinks, newsData, failures, linkLa
   }
 
   actualLinks.forEach((actualLink, index) => {
-    const expectedLink = newsData[index].link;
-    if (actualLink !== expectedLink) {
-      fail(failures, `${label} item ${index + 1} ${linkLabel} ${actualLink} does not match news-data.json link ${expectedLink}`);
+    const article = newsData[index];
+    if (!article || typeof article !== 'object' || Array.isArray(article) || typeof article.link !== 'string') {
+      return;
+    }
+
+    const expectedLink = article.link;
+    const decodedLink = decodeHtmlEntities(actualLink);
+    if (decodedLink !== expectedLink) {
+      fail(failures, `${label} item ${index + 1} ${linkLabel} ${decodedLink} does not match news-data.json link ${expectedLink}`);
     }
   });
 }

--- a/scripts/validate-artifacts.js
+++ b/scripts/validate-artifacts.js
@@ -79,6 +79,19 @@ function isSafeGeneratedArticleHref(value) {
   }
 }
 
+function normalizeGeneratedArticleLink(value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return url.toString();
+    }
+  } catch {
+    // Unsafe or malformed generated hrefs are reported by the safety check.
+  }
+
+  return value;
+}
+
 function extractArticleHrefs(indexHtml) {
   const hrefs = [];
   const articlePattern = /<article\b[^>]*class="[^"]*\bnews-item\b[^"]*"[^>]*>[\s\S]*?<\/article>/gi;
@@ -282,13 +295,21 @@ function validateArtifacts(repoRoot = path.join(__dirname, '..')) {
       }
     });
 
-    assertLinksMatchNewsData(
-      'index.html article',
-      articleHrefs.map(decodeHtmlEntities),
-      newsData,
-      failures,
-      'href'
-    );
+    const normalizedArticleHrefs = articleHrefs
+      .map(decodeHtmlEntities)
+      .map(normalizeGeneratedArticleLink);
+    const normalizedNewsData = newsData.map((article) => {
+      if (!article || typeof article !== 'object' || Array.isArray(article) || typeof article.link !== 'string') {
+        return article;
+      }
+
+      return {
+        ...article,
+        link: normalizeGeneratedArticleLink(article.link),
+      };
+    });
+
+    assertLinksMatchNewsData('index.html article', normalizedArticleHrefs, normalizedNewsData, failures, 'href');
   }
 
   const itemCount = Array.isArray(newsData) ? newsData.length : 0;
@@ -321,5 +342,6 @@ module.exports = {
   extractFeedItemLinks,
   extractArticleHrefs,
   isSafeGeneratedArticleHref,
+  normalizeGeneratedArticleLink,
   validateArtifacts,
 };

--- a/test/validate-artifacts.test.js
+++ b/test/validate-artifacts.test.js
@@ -61,7 +61,7 @@ function createFixture(overrides = {}) {
     overrides.feedXml ||
       `<?xml version="1.0" encoding="UTF-8"?><rss><channel>
         <atom:link href="https://ricomanifesto.github.io/SentryDigest/feed.xml" />
-        ${newsData.map((item) => `<item><title>${item.title}</title></item>`).join('\n')}
+        ${newsData.map((item) => `<item><title>${item.title}</title><link>${item.link}</link></item>`).join('\n')}
       </channel></rss>`
   );
   writeText(
@@ -70,7 +70,7 @@ function createFixture(overrides = {}) {
       `<html><body>
         <h1>SentryDigest</h1>
         <a href="./feed.xml">RSS</a>
-        ${newsData.map((item) => `<article class="news-item">${item.title}</article>`).join('\n')}
+        ${newsData.map((item) => `<article class="news-item"><a href="${item.link}">${item.title}</a></article>`).join('\n')}
       </body></html>`
   );
 
@@ -111,6 +111,43 @@ test('validateArtifacts reports every changed downstream artifact mismatch', () 
   );
   assert.match(result.failures.join('\n'), /feed\.xml has 1 items, expected 2/);
   assert.match(result.failures.join('\n'), /index\.html renders 1 article cards, expected 2/);
+});
+
+test('validateArtifacts rejects feed links that drift from news-data', () => {
+  const repoRoot = createFixture({
+    feedXml: `<?xml version="1.0" encoding="UTF-8"?><rss><channel>
+      <atom:link href="https://ricomanifesto.github.io/SentryDigest/feed.xml" />
+      <item><title>Newer item</title><link>https://example.com/wrong-newer</link></item>
+      <item><title>Older item</title><link>https://example.com/older</link></item>
+    </channel></rss>`,
+  });
+
+  const result = validateArtifacts(repoRoot);
+
+  assert.equal(result.valid, false);
+  assert.match(
+    result.failures.join('\n'),
+    /feed\.xml item 1 link https:\/\/example\.com\/wrong-newer does not match news-data\.json link https:\/\/example\.com\/newer/
+  );
+});
+
+test('validateArtifacts rejects generated HTML article links that drift from news-data', () => {
+  const repoRoot = createFixture({
+    indexHtml: `<html><body>
+      <h1>SentryDigest</h1>
+      <a href="./feed.xml">RSS</a>
+      <article class="news-item"><a href="https://example.com/wrong-newer">Newer item</a></article>
+      <article class="news-item"><a href="https://example.com/older">Older item</a></article>
+    </body></html>`,
+  });
+
+  const result = validateArtifacts(repoRoot);
+
+  assert.equal(result.valid, false);
+  assert.match(
+    result.failures.join('\n'),
+    /index\.html article item 1 href https:\/\/example\.com\/wrong-newer does not match news-data\.json link https:\/\/example\.com\/newer/
+  );
 });
 
 test('validateArtifacts reports missing generated artifacts', () => {

--- a/test/validate-artifacts.test.js
+++ b/test/validate-artifacts.test.js
@@ -174,6 +174,30 @@ test('validateArtifacts accepts escaped generated HTML article hrefs', () => {
   assert.deepEqual(result.failures, []);
 });
 
+test('validateArtifacts accepts renderer-normalized generated HTML article hrefs', () => {
+  const repoRoot = createFixture({
+    newsData: [
+      {
+        title: 'Normalized item',
+        link: 'https://example.com',
+        date: '2026-06-17T18:00:00.000Z',
+        source: 'Example Security',
+        summary: 'Story with normalized URL',
+      },
+    ],
+    indexHtml: `<html><body>
+      <h1>SentryDigest</h1>
+      <a href="./feed.xml">RSS</a>
+      <article class="news-item"><a href="https://example.com/">Normalized item</a></article>
+    </body></html>`,
+  });
+
+  const result = validateArtifacts(repoRoot);
+
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.failures, []);
+});
+
 test('validateArtifacts reports malformed news-data items without throwing during link comparison', () => {
   const repoRoot = createFixture({
     newsData: [null],

--- a/test/validate-artifacts.test.js
+++ b/test/validate-artifacts.test.js
@@ -150,6 +150,51 @@ test('validateArtifacts rejects generated HTML article links that drift from new
   );
 });
 
+test('validateArtifacts accepts escaped generated HTML article hrefs', () => {
+  const repoRoot = createFixture({
+    newsData: [
+      {
+        title: 'Query item',
+        link: 'https://example.com/article?x=1&y=2',
+        date: '2026-06-17T18:00:00.000Z',
+        source: 'Example Security',
+        summary: 'Story with query params',
+      },
+    ],
+    indexHtml: `<html><body>
+      <h1>SentryDigest</h1>
+      <a href="./feed.xml">RSS</a>
+      <article class="news-item"><a href="https://example.com/article?x=1&amp;y=2">Query item</a></article>
+    </body></html>`,
+  });
+
+  const result = validateArtifacts(repoRoot);
+
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test('validateArtifacts reports malformed news-data items without throwing during link comparison', () => {
+  const repoRoot = createFixture({
+    newsData: [null],
+    feedXml: `<?xml version="1.0" encoding="UTF-8"?><rss><channel>
+      <atom:link href="https://ricomanifesto.github.io/SentryDigest/feed.xml" />
+      <item><title>Malformed</title><link>https://example.com/malformed</link></item>
+    </channel></rss>`,
+    indexHtml: `<html><body>
+      <h1>SentryDigest</h1>
+      <a href="./feed.xml">RSS</a>
+      <article class="news-item"><a href="https://example.com/malformed">Malformed</a></article>
+    </body></html>`,
+  });
+
+  assert.doesNotThrow(() => validateArtifacts(repoRoot));
+
+  const result = validateArtifacts(repoRoot);
+  assert.equal(result.valid, false);
+  assert.match(result.failures.join('\n'), /news-data item 1 must be an object/);
+});
+
 test('validateArtifacts reports missing generated artifacts', () => {
   const repoRoot = createFixture();
   fs.rmSync(path.join(repoRoot, 'feed.xml'));


### PR DESCRIPTION
## Summary
- Validate feed item links against news-data links.
- Validate generated article hrefs against news-data links.
- Add regression coverage for same-count link drift.

## Validation
- npm test