### PR TITLE
Add expandable article summaries

### DIFF
--- a/config/news-sources.json
+++ b/config/news-sources.json
@@ -33,7 +33,7 @@
   ],
   "settings": {
     "maxNewsItems": 30,
-    "lastUpdated": "2026-06-23T13:08:57.154Z",
+    "lastUpdated": "2026-06-23T13:18:54.917Z",
     "testTrigger": true,
     "manualTrigger": "2025-09-19T13:55:00.000Z",
     "sortMode": "recent"

--- a/feed-info.json
+++ b/feed-info.json
@@ -9,5 +9,5 @@
     "Bleeping Computer",
     "Dark Reading"
   ],
-  "lastUpdated": "2026-06-23T13:08:57.216Z"
+  "lastUpdated": "2026-06-23T13:18:54.979Z"
 }

--- a/feed.xml
+++ b/feed.xml
@@ -9,9 +9,9 @@
             <link>https://ricomanifesto.github.io/SentryDigest/</link>
         </image>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Tue, 23 Jun 2026 13:08:57 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 23 Jun 2026 13:18:54 GMT</lastBuildDate>
         <atom:link href="https://ricomanifesto.github.io/SentryDigest/feed.xml" rel="self" type="application/rss+xml"/>
-        <pubDate>Tue, 23 Jun 2026 13:08:57 GMT</pubDate>
+        <pubDate>Tue, 23 Jun 2026 13:18:54 GMT</pubDate>
         <language><![CDATA[en]]></language>
         <ttl>180</ttl>
         <comment>News aggregated from: Krebs on Security, The Hacker News, Threatpost, Bleeping Computer, Dark Reading</comment>

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
         <option value="Fortinet">Fortinet</option><option value="GitHub">GitHub</option><option value="Google">Google</option><option value="Microsoft">Microsoft</option><option value="OpenAI">OpenAI</option>
       </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:17:28.186Z">6/23/2026, 8:17:28 AM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:17:52.126Z">6/23/2026, 8:17:52 AM</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
@@ -145,8 +145,10 @@
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Identity</span></div>
           <p class="news-summary summary-preview" id="summary-preview-0">The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global...</p>
-          <p class="news-summary summary-full" id="summary-full-0" hidden>The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global campaign....</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-0" data-summary-toggle="0">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-0">The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global campaign....</p>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Webinar: Why email security teams are drowning in alerts" data-summary="Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl..." data-severity="Elevated" data-tags="Identity,AI Security" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -162,8 +164,10 @@
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-1">Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can...</p>
-          <p class="news-summary summary-full" id="summary-full-1" hidden>Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-1" data-summary-toggle="1">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-1">Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl...</p>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Agentic AI: The Weapon That No Longer Needs a Warrior" data-summary="Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -179,8 +183,10 @@
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-2">Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The...</p>
-          <p class="news-summary summary-full" id="summary-full-2" hidden>Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-2" data-summary-toggle="2">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-2">Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile...</p>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT" data-summary="Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
 
@@ -203,13 +209,15 @@ The list of identified packages, is below -
           <p class="news-summary summary-preview" id="summary-preview-3">Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
 
 The list of...</p>
-          <p class="news-summary summary-full" id="summary-full-3" hidden>Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-3">Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
 
 The list of identified packages, is below -
 
 
   aes-...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-3" data-summary-toggle="3">Show full summary</button>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool" data-summary="Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -224,8 +232,10 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <p class="news-summary summary-preview" id="summary-preview-4">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate...</p>
-          <p class="news-summary summary-full" id="summary-full-4" hidden>Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-4" data-summary-toggle="4">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-4">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar...</p>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws" data-summary="OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="OpenAI" data-source-signal="Industry media">
           <div class="chips">
@@ -241,8 +251,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">OpenAI</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-5">OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial...</p>
-          <p class="news-summary summary-full" id="summary-full-5" hidden>OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-5" data-summary-toggle="5">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-5">OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont...</p>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="WhatsApp phishing attack uses fake business docs to hack PCs" data-summary="An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]..." data-severity="Elevated" data-tags="Identity,Malware" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -258,8 +270,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">Malware</span></div>
           <p class="news-summary summary-preview" id="summary-preview-6">An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system...</p>
-          <p class="news-summary summary-full" id="summary-full-6" hidden>An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-6" data-summary-toggle="6">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-6">An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]...</p>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="JaredFromSubway MEV bot hacked in $15 million crypto theft" data-summary="The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -274,8 +288,10 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <p class="news-summary summary-preview" id="summary-preview-7">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by...</p>
-          <p class="news-summary summary-full" id="summary-full-7" hidden>The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-7" data-summary-toggle="7">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-7">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor...</p>
+          </details>
         </article>
         <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories" data-summary="Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data...." data-severity="Elevated" data-tags="Vulnerability,Exploitation,AI Security" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -291,8 +307,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-8">Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive...</p>
-          <p class="news-summary summary-full" id="summary-full-8" hidden>Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data....</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-8" data-summary-toggle="8">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-8">Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data....</p>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FFmpeg fixes PixelSmash flaw in widely used video decoder" data-summary="A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -308,8 +326,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
           <p class="news-summary summary-preview" id="summary-preview-9">A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also...</p>
-          <p class="news-summary summary-full" id="summary-full-9" hidden>A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-9" data-summary-toggle="9">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-9">A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl...</p>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FortiBleed campaign used custom FortiGate sniffer to steal credentials" data-summary="Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="Fortinet" data-source-signal="Industry media">
           <div class="chips">
@@ -325,8 +345,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <p class="news-summary summary-preview" id="summary-preview-10">Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets...</p>
-          <p class="news-summary summary-full" id="summary-full-10" hidden>Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-10" data-summary-toggle="10">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-10">Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent...</p>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack" data-summary="Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
 
@@ -344,10 +366,12 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
           <p class="news-summary summary-preview" id="summary-preview-11">Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release...</p>
-          <p class="news-summary summary-full" id="summary-full-11" hidden>Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-11">Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
 
 &quot;Attack...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-11" data-summary-toggle="11">Show full summary</button>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft says Windows 11 26H2 is coming soon, details upgrade process" data-summary="Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]..." data-severity="Monitor" data-tags="" data-vendors="Microsoft" data-source-signal="Industry media">
           <div class="chips">
@@ -363,8 +387,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span></div>
           <p class="news-summary summary-preview" id="summary-preview-12">Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade...</p>
-          <p class="news-summary summary-full" id="summary-full-12" hidden>Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-12" data-summary-toggle="12">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-12">Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]...</p>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft fixes AutoGen Studio flaw that enabled code execution" data-summary="A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="Microsoft" data-source-signal="Industry media">
           <div class="chips">
@@ -380,8 +406,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-13">A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing...</p>
-          <p class="news-summary summary-full" id="summary-full-13" hidden>A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-13" data-summary-toggle="13">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-13">A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim...</p>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests" data-summary="A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -397,8 +425,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <p class="news-summary summary-preview" id="summary-preview-14">A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone...</p>
-          <p class="news-summary summary-full" id="summary-full-14" hidden>A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-14" data-summary-toggle="14">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-14">A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa...</p>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants" data-summary="Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="GitHub" data-source-signal="Industry media">
           <div class="chips">
@@ -414,8 +444,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-15">Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars,...</p>
-          <p class="news-summary summary-full" id="summary-full-15" hidden>Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-15" data-summary-toggle="15">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-15">Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily...</p>
+          </details>
         </article>
         <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign" data-summary="Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker...." data-severity="Monitor" data-tags="" data-vendors="GitHub" data-source-signal="Industry media">
           <div class="chips">
@@ -431,8 +463,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">GitHub</span></div>
           <p class="news-summary summary-preview" id="summary-preview-16">Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard...</p>
-          <p class="news-summary summary-full" id="summary-full-16" hidden>Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker....</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-16" data-summary-toggle="16">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-16">Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker....</p>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="A Glimpse into the “Search Your Target” Market for Stolen Credentials" data-summary="Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -448,8 +482,10 @@ The list of identified packages, is below -
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <p class="news-summary summary-preview" id="summary-preview-17">Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market...</p>
-          <p class="news-summary summary-full" id="summary-full-17" hidden>Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-17" data-summary-toggle="17">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-17">Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe...</p>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer" data-summary="Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
 
@@ -467,10 +503,12 @@ According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Mal
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Malware</span></div>
           <p class="news-summary summary-preview" id="summary-preview-18">Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed...</p>
-          <p class="news-summary summary-full" id="summary-full-18" hidden>Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-18">Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
 
 According to Elastic Security Labs, ...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-18" data-summary-toggle="18">Show full summary</button>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries" data-summary="Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app stores are in from the start.
 
@@ -487,10 +525,12 @@ On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data
           </div>
           <div class="facet-row"><span class="chip">Google</span></div>
           <p class="news-summary summary-preview" id="summary-preview-19">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app...</p>
-          <p class="news-summary summary-full" id="summary-full-19" hidden>Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app stores are in from the start.
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-19">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app stores are in from the start.
 
 On that date...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-19" data-summary-toggle="19">Show full summary</button>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Stop Your Legacy Infrastructure from Hijacking Your AI Agents" data-summary="Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -505,8 +545,10 @@ On that date...</p>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-20">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how...</p>
-          <p class="news-summary summary-full" id="summary-full-20" hidden>Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-20" data-summary-toggle="20">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-20">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra...</p>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More" data-summary="It’s Monday again.
 
@@ -525,10 +567,12 @@ This week’s threat list looks painfully familiar: abused integrations, fake to
           <p class="news-summary summary-preview" id="summary-preview-21">It’s Monday again.
 
 This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down...</p>
-          <p class="news-summary summary-full" id="summary-full-21" hidden>It’s Monday again.
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-21">It’s Monday again.
 
 This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down security tools, and mobile malware asking...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-21" data-summary-toggle="21">Show full summary</button>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices" data-summary="Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
 
@@ -545,10 +589,12 @@ The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" 
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <p class="news-summary summary-preview" id="summary-preview-22">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two...</p>
-          <p class="news-summary summary-full" id="summary-full-22" hidden>Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-22">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
 
 The Federal Court released a ...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-22" data-summary-toggle="22">Show full summary</button>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network" data-summary="A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -563,8 +609,10 @@ The Federal Court released a ...</p>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <p class="news-summary summary-preview" id="summary-preview-23">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up...</p>
-          <p class="news-summary summary-full" id="summary-full-23" hidden>A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-23" data-summary-toggle="23">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-23">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific" data-summary="A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne..." data-severity="Critical" data-tags="Ransomware,Identity,AI Security" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -579,8 +627,10 @@ The Federal Court released a ...</p>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span><span class="chip">Identity</span><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-24">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet...</p>
-          <p class="news-summary summary-full" id="summary-full-24" hidden>A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-24" data-summary-toggle="24">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-24">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne...</p>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="AryStinger botnet infected thousands of D-Link routers worldwide" data-summary="A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -595,8 +645,10 @@ The Federal Court released a ...</p>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <p class="news-summary summary-preview" id="summary-preview-25">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic....</p>
-          <p class="news-summary summary-full" id="summary-full-25" hidden>A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-25" data-summary-toggle="25">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-25">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]...</p>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="New Prinz Eugen ransomware prioritizes recent files for encryption" data-summary="A new ransomware operation named &#39;Prinz Eugen&#39; prioritizes recently modified files for encryption and leaves no ransom note on the system. [...]..." data-severity="Critical" data-tags="Ransomware" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -625,8 +677,10 @@ The Federal Court released a ...</p>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Supply Chain</span><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-27">Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet,...</p>
-          <p class="news-summary summary-full" id="summary-full-27" hidden>Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet, also known as BlueNoroff. [...]...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-27" data-summary-toggle="27">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-27">Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet, also known as BlueNoroff. [...]...</p>
+          </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Hackers Exploit Gravity SMTP WordPress Plugin Bug to Expose API Keys" data-summary="Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
 
@@ -645,10 +699,12 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco..." data-severity="Elevate
           <p class="news-summary summary-preview" id="summary-preview-28">Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
 
 The...</p>
-          <p class="news-summary summary-full" id="summary-full-28" hidden>Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-28">Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
 
 The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-28" data-summary-toggle="28">Show full summary</button>
+          </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Klue OAuth breach victim list grows as Icarus hackers claim attack" data-summary="Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to customers&#39; Salesforce environments, as the new &quot;..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -663,8 +719,10 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <p class="news-summary summary-preview" id="summary-preview-29">Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to...</p>
-          <p class="news-summary summary-full" id="summary-full-29" hidden>Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to customers&#39; Salesforce environments, as the new &quot;...</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-29" data-summary-toggle="29">Show full summary</button>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-29">Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to customers&#39; Salesforce environments, as the new &quot;...</p>
+          </details>
         </article>
     </div>
   </main>
@@ -720,7 +778,7 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:17:28.186Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:17:52.126Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));
@@ -728,18 +786,6 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
         if (filter) filter.addEventListener('change', update);
       });
 
-      qa('[data-summary-toggle]').forEach(function(toggle){
-        toggle.addEventListener('click', function(){
-          const id = toggle.getAttribute('data-summary-toggle');
-          const summaryPreview = q('#summary-preview-' + id);
-          const summaryFull = q('#summary-full-' + id);
-          const expanded = toggle.getAttribute('aria-expanded') === 'true';
-          if (summaryPreview) summaryPreview.hidden = !expanded;
-          if (summaryFull) summaryFull.hidden = expanded;
-          toggle.setAttribute('aria-expanded', String(!expanded));
-          toggle.textContent = expanded ? 'Show full summary' : 'Show less';
-        });
-      });
       update();
 
       function debounce(fn, wait){ let t; return function(){ clearTimeout(t); t=setTimeout(fn, wait); } }

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
         <option value="Fortinet">Fortinet</option><option value="GitHub">GitHub</option><option value="Google">Google</option><option value="Microsoft">Microsoft</option><option value="OpenAI">OpenAI</option>
       </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:17:01.028Z">6/23/2026, 8:17:01 AM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:17:28.186Z">6/23/2026, 8:17:28 AM</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
@@ -144,7 +144,9 @@
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Identity</span></div>
-          <p class="news-summary">The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global campaign....</p>
+          <p class="news-summary summary-preview" id="summary-preview-0">The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global...</p>
+          <p class="news-summary summary-full" id="summary-full-0" hidden>The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global campaign....</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-0" data-summary-toggle="0">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Webinar: Why email security teams are drowning in alerts" data-summary="Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl..." data-severity="Elevated" data-tags="Identity,AI Security" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -159,7 +161,9 @@
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">AI Security</span></div>
-          <p class="news-summary">Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl...</p>
+          <p class="news-summary summary-preview" id="summary-preview-1">Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can...</p>
+          <p class="news-summary summary-full" id="summary-full-1" hidden>Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-1" data-summary-toggle="1">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Agentic AI: The Weapon That No Longer Needs a Warrior" data-summary="Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -174,7 +178,9 @@
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
-          <p class="news-summary">Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile...</p>
+          <p class="news-summary summary-preview" id="summary-preview-2">Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The...</p>
+          <p class="news-summary summary-full" id="summary-full-2" hidden>Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-2" data-summary-toggle="2">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT" data-summary="Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
 
@@ -194,12 +200,16 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
-          <p class="news-summary">Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
+          <p class="news-summary summary-preview" id="summary-preview-3">Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
+
+The list of...</p>
+          <p class="news-summary summary-full" id="summary-full-3" hidden>Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
 
 The list of identified packages, is below -
 
 
   aes-...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-3" data-summary-toggle="3">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool" data-summary="Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -213,7 +223,9 @@ The list of identified packages, is below -
             <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 12:38 AM</time>
             <span class="badge-new">NEW</span>
           </div>
-          <p class="news-summary">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar...</p>
+          <p class="news-summary summary-preview" id="summary-preview-4">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate...</p>
+          <p class="news-summary summary-full" id="summary-full-4" hidden>Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-4" data-summary-toggle="4">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws" data-summary="OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="OpenAI" data-source-signal="Industry media">
           <div class="chips">
@@ -228,7 +240,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">OpenAI</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
-          <p class="news-summary">OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont...</p>
+          <p class="news-summary summary-preview" id="summary-preview-5">OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial...</p>
+          <p class="news-summary summary-full" id="summary-full-5" hidden>OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-5" data-summary-toggle="5">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="WhatsApp phishing attack uses fake business docs to hack PCs" data-summary="An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]..." data-severity="Elevated" data-tags="Identity,Malware" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -243,7 +257,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">Malware</span></div>
-          <p class="news-summary">An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]...</p>
+          <p class="news-summary summary-preview" id="summary-preview-6">An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system...</p>
+          <p class="news-summary summary-full" id="summary-full-6" hidden>An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-6" data-summary-toggle="6">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="JaredFromSubway MEV bot hacked in $15 million crypto theft" data-summary="The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -257,7 +273,9 @@ The list of identified packages, is below -
             <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 4:52 PM</time>
             <span class="badge-new">NEW</span>
           </div>
-          <p class="news-summary">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor...</p>
+          <p class="news-summary summary-preview" id="summary-preview-7">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by...</p>
+          <p class="news-summary summary-full" id="summary-full-7" hidden>The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-7" data-summary-toggle="7">Show full summary</button>
         </article>
         <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories" data-summary="Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data...." data-severity="Elevated" data-tags="Vulnerability,Exploitation,AI Security" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -272,7 +290,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span><span class="chip">AI Security</span></div>
-          <p class="news-summary">Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data....</p>
+          <p class="news-summary summary-preview" id="summary-preview-8">Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive...</p>
+          <p class="news-summary summary-full" id="summary-full-8" hidden>Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data....</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-8" data-summary-toggle="8">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FFmpeg fixes PixelSmash flaw in widely used video decoder" data-summary="A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -287,7 +307,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
-          <p class="news-summary">A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl...</p>
+          <p class="news-summary summary-preview" id="summary-preview-9">A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also...</p>
+          <p class="news-summary summary-full" id="summary-full-9" hidden>A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-9" data-summary-toggle="9">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FortiBleed campaign used custom FortiGate sniffer to steal credentials" data-summary="Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="Fortinet" data-source-signal="Industry media">
           <div class="chips">
@@ -302,7 +324,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
-          <p class="news-summary">Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent...</p>
+          <p class="news-summary summary-preview" id="summary-preview-10">Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets...</p>
+          <p class="news-summary summary-full" id="summary-full-10" hidden>Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-10" data-summary-toggle="10">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack" data-summary="Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
 
@@ -319,9 +343,11 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
-          <p class="news-summary">Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
+          <p class="news-summary summary-preview" id="summary-preview-11">Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release...</p>
+          <p class="news-summary summary-full" id="summary-full-11" hidden>Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
 
 &quot;Attack...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-11" data-summary-toggle="11">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft says Windows 11 26H2 is coming soon, details upgrade process" data-summary="Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]..." data-severity="Monitor" data-tags="" data-vendors="Microsoft" data-source-signal="Industry media">
           <div class="chips">
@@ -336,7 +362,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span></div>
-          <p class="news-summary">Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]...</p>
+          <p class="news-summary summary-preview" id="summary-preview-12">Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade...</p>
+          <p class="news-summary summary-full" id="summary-full-12" hidden>Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-12" data-summary-toggle="12">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft fixes AutoGen Studio flaw that enabled code execution" data-summary="A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="Microsoft" data-source-signal="Industry media">
           <div class="chips">
@@ -351,7 +379,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
-          <p class="news-summary">A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim...</p>
+          <p class="news-summary summary-preview" id="summary-preview-13">A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing...</p>
+          <p class="news-summary summary-full" id="summary-full-13" hidden>A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-13" data-summary-toggle="13">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests" data-summary="A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -366,7 +396,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
-          <p class="news-summary">A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa...</p>
+          <p class="news-summary summary-preview" id="summary-preview-14">A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone...</p>
+          <p class="news-summary summary-full" id="summary-full-14" hidden>A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-14" data-summary-toggle="14">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants" data-summary="Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="GitHub" data-source-signal="Industry media">
           <div class="chips">
@@ -381,7 +413,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
-          <p class="news-summary">Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily...</p>
+          <p class="news-summary summary-preview" id="summary-preview-15">Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars,...</p>
+          <p class="news-summary summary-full" id="summary-full-15" hidden>Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-15" data-summary-toggle="15">Show full summary</button>
         </article>
         <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign" data-summary="Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker...." data-severity="Monitor" data-tags="" data-vendors="GitHub" data-source-signal="Industry media">
           <div class="chips">
@@ -396,7 +430,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span></div>
-          <p class="news-summary">Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker....</p>
+          <p class="news-summary summary-preview" id="summary-preview-16">Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard...</p>
+          <p class="news-summary summary-full" id="summary-full-16" hidden>Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker....</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-16" data-summary-toggle="16">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="A Glimpse into the “Search Your Target” Market for Stolen Credentials" data-summary="Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -411,7 +447,9 @@ The list of identified packages, is below -
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
-          <p class="news-summary">Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe...</p>
+          <p class="news-summary summary-preview" id="summary-preview-17">Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market...</p>
+          <p class="news-summary summary-full" id="summary-full-17" hidden>Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-17" data-summary-toggle="17">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer" data-summary="Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
 
@@ -428,9 +466,11 @@ According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Mal
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Malware</span></div>
-          <p class="news-summary">Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
+          <p class="news-summary summary-preview" id="summary-preview-18">Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed...</p>
+          <p class="news-summary summary-full" id="summary-full-18" hidden>Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
 
 According to Elastic Security Labs, ...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-18" data-summary-toggle="18">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries" data-summary="Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app stores are in from the start.
 
@@ -446,9 +486,11 @@ On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data
             <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 7:45 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span></div>
-          <p class="news-summary">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app stores are in from the start.
+          <p class="news-summary summary-preview" id="summary-preview-19">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app...</p>
+          <p class="news-summary summary-full" id="summary-full-19" hidden>Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app stores are in from the start.
 
 On that date...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-19" data-summary-toggle="19">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Stop Your Legacy Infrastructure from Hijacking Your AI Agents" data-summary="Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -462,7 +504,9 @@ On that date...</p>
             <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 6:58 AM</time>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
-          <p class="news-summary">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra...</p>
+          <p class="news-summary summary-preview" id="summary-preview-20">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how...</p>
+          <p class="news-summary summary-full" id="summary-full-20" hidden>Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-20" data-summary-toggle="20">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More" data-summary="It’s Monday again.
 
@@ -478,9 +522,13 @@ This week’s threat list looks painfully familiar: abused integrations, fake to
             <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 5:55 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Ransomware</span><span class="chip">Vulnerability</span><span class="chip">Malware</span></div>
-          <p class="news-summary">It’s Monday again.
+          <p class="news-summary summary-preview" id="summary-preview-21">It’s Monday again.
+
+This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down...</p>
+          <p class="news-summary summary-full" id="summary-full-21" hidden>It’s Monday again.
 
 This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down security tools, and mobile malware asking...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-21" data-summary-toggle="21">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices" data-summary="Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
 
@@ -496,9 +544,11 @@ The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" 
             <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 4:11 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
-          <p class="news-summary">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
+          <p class="news-summary summary-preview" id="summary-preview-22">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two...</p>
+          <p class="news-summary summary-full" id="summary-full-22" hidden>Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
 
 The Federal Court released a ...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-22" data-summary-toggle="22">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network" data-summary="A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -512,7 +562,9 @@ The Federal Court released a ...</p>
             <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 1:57 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
-          <p class="news-summary">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
+          <p class="news-summary summary-preview" id="summary-preview-23">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up...</p>
+          <p class="news-summary summary-full" id="summary-full-23" hidden>A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-23" data-summary-toggle="23">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific" data-summary="A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne..." data-severity="Critical" data-tags="Ransomware,Identity,AI Security" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -526,7 +578,9 @@ The Federal Court released a ...</p>
             <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 1:06 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span><span class="chip">Identity</span><span class="chip">AI Security</span></div>
-          <p class="news-summary">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne...</p>
+          <p class="news-summary summary-preview" id="summary-preview-24">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet...</p>
+          <p class="news-summary summary-full" id="summary-full-24" hidden>A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-24" data-summary-toggle="24">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="AryStinger botnet infected thousands of D-Link routers worldwide" data-summary="A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -540,7 +594,9 @@ The Federal Court released a ...</p>
             <time datetime="2026-06-21T14:14:22.000Z">June 21, 2026 at 9:14 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
-          <p class="news-summary">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]...</p>
+          <p class="news-summary summary-preview" id="summary-preview-25">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic....</p>
+          <p class="news-summary summary-full" id="summary-full-25" hidden>A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-25" data-summary-toggle="25">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="New Prinz Eugen ransomware prioritizes recent files for encryption" data-summary="A new ransomware operation named &#39;Prinz Eugen&#39; prioritizes recently modified files for encryption and leaves no ransom note on the system. [...]..." data-severity="Critical" data-tags="Ransomware" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -568,7 +624,9 @@ The Federal Court released a ...</p>
             <time datetime="2026-06-20T14:09:19.000Z">June 20, 2026 at 9:09 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Supply Chain</span><span class="chip">AI Security</span></div>
-          <p class="news-summary">Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet, also known as BlueNoroff. [...]...</p>
+          <p class="news-summary summary-preview" id="summary-preview-27">Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet,...</p>
+          <p class="news-summary summary-full" id="summary-full-27" hidden>Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet, also known as BlueNoroff. [...]...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-27" data-summary-toggle="27">Show full summary</button>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Hackers Exploit Gravity SMTP WordPress Plugin Bug to Expose API Keys" data-summary="Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
 
@@ -584,9 +642,13 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco..." data-severity="Elevate
             <time datetime="2026-06-20T09:56:04.000Z">June 20, 2026 at 4:56 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
-          <p class="news-summary">Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
+          <p class="news-summary summary-preview" id="summary-preview-28">Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
+
+The...</p>
+          <p class="news-summary summary-full" id="summary-full-28" hidden>Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
 
 The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-28" data-summary-toggle="28">Show full summary</button>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Klue OAuth breach victim list grows as Icarus hackers claim attack" data-summary="Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to customers&#39; Salesforce environments, as the new &quot;..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
           <div class="chips">
@@ -600,7 +662,9 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
             <time datetime="2026-06-19T22:31:04.000Z">June 19, 2026 at 5:31 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
-          <p class="news-summary">Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to customers&#39; Salesforce environments, as the new &quot;...</p>
+          <p class="news-summary summary-preview" id="summary-preview-29">Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to...</p>
+          <p class="news-summary summary-full" id="summary-full-29" hidden>Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to customers&#39; Salesforce environments, as the new &quot;...</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-29" data-summary-toggle="29">Show full summary</button>
         </article>
     </div>
   </main>
@@ -656,7 +720,7 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:17:01.028Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:17:28.186Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
         <option value="Fortinet">Fortinet</option><option value="GitHub">GitHub</option><option value="Google">Google</option><option value="Microsoft">Microsoft</option><option value="OpenAI">OpenAI</option>
       </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:17:52.126Z">6/23/2026, 8:17:52 AM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:18:54.900Z">6/23/2026, 1:18:54 PM</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
@@ -140,7 +140,7 @@
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/fortibleed-attackers-firewalls-credentials-stealers" target="_blank" rel="noopener">FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 7:34 AM</time>
+            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 12:34 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Identity</span></div>
@@ -159,7 +159,7 @@
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/webinar-why-email-security-teams-are-drowning-in-alerts/" target="_blank" rel="noopener">Webinar: Why email security teams are drowning in alerts</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 7:12 AM</time>
+            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 12:12 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">AI Security</span></div>
@@ -178,7 +178,7 @@
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/agentic-ai-weapon-that-no-longer-needs.html" target="_blank" rel="noopener">Agentic AI: The Weapon That No Longer Needs a Warrior</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 6:30 AM</time>
+            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 11:30 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
@@ -202,7 +202,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/malicious-npm-packages-pose-as-postcss.html" target="_blank" rel="noopener">Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 3:54 AM</time>
+            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 8:54 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
@@ -228,7 +228,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/whatsapp-vbscript-campaign-uses-fake.html" target="_blank" rel="noopener">WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 12:38 AM</time>
+            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 5:38 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <p class="news-summary summary-preview" id="summary-preview-4">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate...</p>
@@ -246,7 +246,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/openai-expands-daybreak-with-gpt-55.html" target="_blank" rel="noopener">OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T03:56:58.000Z">June 22, 2026 at 10:56 PM</time>
+            <time datetime="2026-06-23T03:56:58.000Z">June 23, 2026 at 3:56 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">OpenAI</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -265,7 +265,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/whatsapp-phishing-attack-uses-fake-business-docs-to-hack-pcs/" target="_blank" rel="noopener">WhatsApp phishing attack uses fake business docs to hack PCs</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 5:42 PM</time>
+            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 10:42 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">Malware</span></div>
@@ -284,7 +284,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/jaredfromsubway-mev-bot-hacked-in-15-million-crypto-theft/" target="_blank" rel="noopener">JaredFromSubway MEV bot hacked in $15 million crypto theft</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 4:52 PM</time>
+            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 9:52 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <p class="news-summary summary-preview" id="summary-preview-7">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by...</p>
@@ -302,7 +302,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/application-security/difytap-bugs-wiretap-ai-chat-histories" target="_blank" rel="noopener">DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 4:14 PM</time>
+            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 9:14 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span><span class="chip">AI Security</span></div>
@@ -321,7 +321,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/ffmpeg-fixes-pixelsmash-flaw-in-widely-used-video-decoder/" target="_blank" rel="noopener">FFmpeg fixes PixelSmash flaw in widely used video decoder</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 4:05 PM</time>
+            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 9:05 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
@@ -340,7 +340,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/fortibleed-campaign-used-custom-fortigate-sniffer-to-steal-credentials/" target="_blank" rel="noopener">FortiBleed campaign used custom FortiGate sniffer to steal credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 3:01 PM</time>
+            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 8:01 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
@@ -361,7 +361,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/shapedplugin-wordpress-pro-plugins.html" target="_blank" rel="noopener">ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 1:00 PM</time>
+            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 6:00 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
@@ -382,7 +382,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/microsoft/microsoft-says-windows-11-26h2-is-coming-soon-details-upgrade-process/" target="_blank" rel="noopener">Microsoft says Windows 11 26H2 is coming soon, details upgrade process</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 12:41 PM</time>
+            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 5:41 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span></div>
@@ -401,7 +401,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/microsoft-fixes-autogen-studio-flaw-that-enabled-code-execution/" target="_blank" rel="noopener">Microsoft fixes AutoGen Studio flaw that enabled code execution</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 12:28 PM</time>
+            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 5:28 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -420,7 +420,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/29-year-old-squid-proxy-bug-squidbleed.html" target="_blank" rel="noopener">29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 11:29 AM</time>
+            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 4:29 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
@@ -439,7 +439,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/researchers-detail-difytap-flaws-in.html" target="_blank" rel="noopener">Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 11:13 AM</time>
+            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 4:13 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -458,7 +458,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/crypto-heist-fake-reputation-boosting-campaign" target="_blank" rel="noopener">Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 11:10 AM</time>
+            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 4:10 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span></div>
@@ -477,7 +477,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/a-glimpse-into-the-search-your-target-market-for-stolen-credentials/" target="_blank" rel="noopener">A Glimpse into the “Search Your Target” Market for Stolen Credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 9:05 AM</time>
+            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 2:05 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
@@ -498,7 +498,7 @@ According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Mal
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/new-oxloader-loader-uses-malicious.html" target="_blank" rel="noopener">New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 8:20 AM</time>
+            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 1:20 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Malware</span></div>
@@ -521,7 +521,7 @@ On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/google-sets-sept-30-deadline-for.html" target="_blank" rel="noopener">Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 7:45 AM</time>
+            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 12:45 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span></div>
           <p class="news-summary summary-preview" id="summary-preview-19">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app...</p>
@@ -541,7 +541,7 @@ On that date...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/stop-your-legacy-infrastructure-from.html" target="_blank" rel="noopener">Stop Your Legacy Infrastructure from Hijacking Your AI Agents</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 6:58 AM</time>
+            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 11:58 AM</time>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-20">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how...</p>
@@ -561,7 +561,7 @@ This week’s threat list looks painfully familiar: abused integrations, fake to
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/weekly-recap-browser-bugs-edr-killers.html" target="_blank" rel="noopener">⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 5:55 AM</time>
+            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 10:55 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Ransomware</span><span class="chip">Vulnerability</span><span class="chip">Malware</span></div>
           <p class="news-summary summary-preview" id="summary-preview-21">It’s Monday again.
@@ -585,7 +585,7 @@ The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" 
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/canadas-spy-agency-used-first-of-its.html" target="_blank" rel="noopener">Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 4:11 AM</time>
+            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 9:11 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <p class="news-summary summary-preview" id="summary-preview-22">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two...</p>
@@ -605,7 +605,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/arystinger-malware-infects-4300-legacy.html" target="_blank" rel="noopener">AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 1:57 AM</time>
+            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 6:57 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <p class="news-summary summary-preview" id="summary-preview-23">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up...</p>
@@ -623,7 +623,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/interpol-warns-phishing-ransomware-and.html" target="_blank" rel="noopener">INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 1:06 AM</time>
+            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 6:06 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span><span class="chip">Identity</span><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-24">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet...</p>
@@ -641,7 +641,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/arystinger-botnet-infected-thousands-of-d-link-routers-worldwide/" target="_blank" rel="noopener">AryStinger botnet infected thousands of D-Link routers worldwide</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-21T14:14:22.000Z">June 21, 2026 at 9:14 AM</time>
+            <time datetime="2026-06-21T14:14:22.000Z">June 21, 2026 at 2:14 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <p class="news-summary summary-preview" id="summary-preview-25">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic....</p>
@@ -659,7 +659,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/new-prinz-eugen-ransomware-prioritizes-recent-files-for-encryption/" target="_blank" rel="noopener">New Prinz Eugen ransomware prioritizes recent files for encryption</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-20T15:23:46.000Z">June 20, 2026 at 10:23 AM</time>
+            <time datetime="2026-06-20T15:23:46.000Z">June 20, 2026 at 3:23 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span></div>
           <p class="news-summary">A new ransomware operation named &#39;Prinz Eugen&#39; prioritizes recently modified files for encryption and leaves no ransom note on the system. [...]...</p>
@@ -673,7 +673,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/microsoft-links-mastra-ai-supply-chain-attack-to-north-korean-hackers/" target="_blank" rel="noopener">Microsoft links Mastra AI supply chain attack to North Korean hackers</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-20T14:09:19.000Z">June 20, 2026 at 9:09 AM</time>
+            <time datetime="2026-06-20T14:09:19.000Z">June 20, 2026 at 2:09 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Supply Chain</span><span class="chip">AI Security</span></div>
           <p class="news-summary summary-preview" id="summary-preview-27">Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet,...</p>
@@ -693,7 +693,7 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco..." data-severity="Elevate
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/hackers-exploit-gravity-smtp-wordpress.html" target="_blank" rel="noopener">Hackers Exploit Gravity SMTP WordPress Plugin Bug to Expose API Keys</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-20T09:56:04.000Z">June 20, 2026 at 4:56 AM</time>
+            <time datetime="2026-06-20T09:56:04.000Z">June 20, 2026 at 9:56 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
           <p class="news-summary summary-preview" id="summary-preview-28">Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
@@ -715,7 +715,7 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/klue-oauth-breach-victim-list-grows-as-icarus-hackers-claim-attack/" target="_blank" rel="noopener">Klue OAuth breach victim list grows as Icarus hackers claim attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-19T22:31:04.000Z">June 19, 2026 at 5:31 PM</time>
+            <time datetime="2026-06-19T22:31:04.000Z">June 19, 2026 at 10:31 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <p class="news-summary summary-preview" id="summary-preview-29">Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to...</p>
@@ -778,7 +778,7 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:17:52.126Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:18:54.900Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));

--- a/index.html
+++ b/index.html
@@ -69,6 +69,9 @@
     .news-meta { color: var(--muted); font-size: 0.85rem; display: flex; gap: 8px; align-items: baseline; }
     .badge-new { color: #16a34a; font-weight: 600; font-size: 0.8rem; }
     .news-summary { margin-top: 8px; color: var(--fg); opacity: 0.9; }
+    .summary-toggle { border: none; background: transparent; color: var(--accent); cursor: pointer; font: inherit; font-size: 0.9rem; margin-top: 2px; padding: 0; }
+    .summary-toggle:hover { text-decoration: underline; }
+    .summary-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
     footer { border-top: 1px solid var(--card-border); color: var(--muted); font-size: 0.9rem; padding: 18px 0; margin-top: 22px; }
     @media (max-width: 640px) {
       .container { padding: 16px; }
@@ -123,7 +126,7 @@
         <option value="Fortinet">Fortinet</option><option value="GitHub">GitHub</option><option value="Google">Google</option><option value="Microsoft">Microsoft</option><option value="OpenAI">OpenAI</option>
       </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:08:57.142Z">6/23/2026, 1:08:57 PM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:17:01.028Z">6/23/2026, 8:17:01 AM</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
@@ -137,7 +140,7 @@
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/fortibleed-attackers-firewalls-credentials-stealers" target="_blank" rel="noopener">FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 12:34 PM</time>
+            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 7:34 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Identity</span></div>
@@ -152,7 +155,7 @@
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/webinar-why-email-security-teams-are-drowning-in-alerts/" target="_blank" rel="noopener">Webinar: Why email security teams are drowning in alerts</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 12:12 PM</time>
+            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 7:12 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">AI Security</span></div>
@@ -167,7 +170,7 @@
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/agentic-ai-weapon-that-no-longer-needs.html" target="_blank" rel="noopener">Agentic AI: The Weapon That No Longer Needs a Warrior</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 11:30 AM</time>
+            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 6:30 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
@@ -187,7 +190,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/malicious-npm-packages-pose-as-postcss.html" target="_blank" rel="noopener">Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 8:54 AM</time>
+            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 3:54 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
@@ -207,7 +210,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/whatsapp-vbscript-campaign-uses-fake.html" target="_blank" rel="noopener">WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 5:38 AM</time>
+            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 12:38 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <p class="news-summary">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar...</p>
@@ -221,7 +224,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/openai-expands-daybreak-with-gpt-55.html" target="_blank" rel="noopener">OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T03:56:58.000Z">June 23, 2026 at 3:56 AM</time>
+            <time datetime="2026-06-23T03:56:58.000Z">June 22, 2026 at 10:56 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">OpenAI</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -236,7 +239,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/whatsapp-phishing-attack-uses-fake-business-docs-to-hack-pcs/" target="_blank" rel="noopener">WhatsApp phishing attack uses fake business docs to hack PCs</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 10:42 PM</time>
+            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 5:42 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">Malware</span></div>
@@ -251,7 +254,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/jaredfromsubway-mev-bot-hacked-in-15-million-crypto-theft/" target="_blank" rel="noopener">JaredFromSubway MEV bot hacked in $15 million crypto theft</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 9:52 PM</time>
+            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 4:52 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <p class="news-summary">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor...</p>
@@ -265,7 +268,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/application-security/difytap-bugs-wiretap-ai-chat-histories" target="_blank" rel="noopener">DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 9:14 PM</time>
+            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 4:14 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span><span class="chip">AI Security</span></div>
@@ -280,7 +283,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/ffmpeg-fixes-pixelsmash-flaw-in-widely-used-video-decoder/" target="_blank" rel="noopener">FFmpeg fixes PixelSmash flaw in widely used video decoder</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 9:05 PM</time>
+            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 4:05 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
@@ -295,7 +298,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/fortibleed-campaign-used-custom-fortigate-sniffer-to-steal-credentials/" target="_blank" rel="noopener">FortiBleed campaign used custom FortiGate sniffer to steal credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 8:01 PM</time>
+            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 3:01 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
@@ -312,7 +315,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/shapedplugin-wordpress-pro-plugins.html" target="_blank" rel="noopener">ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 6:00 PM</time>
+            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 1:00 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
@@ -329,7 +332,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/microsoft/microsoft-says-windows-11-26h2-is-coming-soon-details-upgrade-process/" target="_blank" rel="noopener">Microsoft says Windows 11 26H2 is coming soon, details upgrade process</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 5:41 PM</time>
+            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 12:41 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span></div>
@@ -344,7 +347,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/microsoft-fixes-autogen-studio-flaw-that-enabled-code-execution/" target="_blank" rel="noopener">Microsoft fixes AutoGen Studio flaw that enabled code execution</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 5:28 PM</time>
+            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 12:28 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -359,7 +362,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/29-year-old-squid-proxy-bug-squidbleed.html" target="_blank" rel="noopener">29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 4:29 PM</time>
+            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 11:29 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
@@ -374,7 +377,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/researchers-detail-difytap-flaws-in.html" target="_blank" rel="noopener">Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 4:13 PM</time>
+            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 11:13 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -389,7 +392,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/crypto-heist-fake-reputation-boosting-campaign" target="_blank" rel="noopener">Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 4:10 PM</time>
+            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 11:10 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span></div>
@@ -404,7 +407,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/a-glimpse-into-the-search-your-target-market-for-stolen-credentials/" target="_blank" rel="noopener">A Glimpse into the “Search Your Target” Market for Stolen Credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 2:05 PM</time>
+            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 9:05 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
@@ -421,7 +424,7 @@ According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Mal
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/new-oxloader-loader-uses-malicious.html" target="_blank" rel="noopener">New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 1:20 PM</time>
+            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 8:20 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Malware</span></div>
@@ -440,7 +443,7 @@ On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/google-sets-sept-30-deadline-for.html" target="_blank" rel="noopener">Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 12:45 PM</time>
+            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 7:45 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span></div>
           <p class="news-summary">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app stores are in from the start.
@@ -456,7 +459,7 @@ On that date...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/stop-your-legacy-infrastructure-from.html" target="_blank" rel="noopener">Stop Your Legacy Infrastructure from Hijacking Your AI Agents</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 11:58 AM</time>
+            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 6:58 AM</time>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
           <p class="news-summary">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra...</p>
@@ -472,7 +475,7 @@ This week’s threat list looks painfully familiar: abused integrations, fake to
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/weekly-recap-browser-bugs-edr-killers.html" target="_blank" rel="noopener">⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 10:55 AM</time>
+            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 5:55 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Ransomware</span><span class="chip">Vulnerability</span><span class="chip">Malware</span></div>
           <p class="news-summary">It’s Monday again.
@@ -490,7 +493,7 @@ The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" 
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/canadas-spy-agency-used-first-of-its.html" target="_blank" rel="noopener">Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 9:11 AM</time>
+            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 4:11 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <p class="news-summary">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
@@ -506,7 +509,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/arystinger-malware-infects-4300-legacy.html" target="_blank" rel="noopener">AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 6:57 AM</time>
+            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 1:57 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <p class="news-summary">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
@@ -520,7 +523,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/interpol-warns-phishing-ransomware-and.html" target="_blank" rel="noopener">INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 6:06 AM</time>
+            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 1:06 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span><span class="chip">Identity</span><span class="chip">AI Security</span></div>
           <p class="news-summary">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne...</p>
@@ -534,7 +537,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/arystinger-botnet-infected-thousands-of-d-link-routers-worldwide/" target="_blank" rel="noopener">AryStinger botnet infected thousands of D-Link routers worldwide</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-21T14:14:22.000Z">June 21, 2026 at 2:14 PM</time>
+            <time datetime="2026-06-21T14:14:22.000Z">June 21, 2026 at 9:14 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <p class="news-summary">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]...</p>
@@ -548,7 +551,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/new-prinz-eugen-ransomware-prioritizes-recent-files-for-encryption/" target="_blank" rel="noopener">New Prinz Eugen ransomware prioritizes recent files for encryption</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-20T15:23:46.000Z">June 20, 2026 at 3:23 PM</time>
+            <time datetime="2026-06-20T15:23:46.000Z">June 20, 2026 at 10:23 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span></div>
           <p class="news-summary">A new ransomware operation named &#39;Prinz Eugen&#39; prioritizes recently modified files for encryption and leaves no ransom note on the system. [...]...</p>
@@ -562,7 +565,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/microsoft-links-mastra-ai-supply-chain-attack-to-north-korean-hackers/" target="_blank" rel="noopener">Microsoft links Mastra AI supply chain attack to North Korean hackers</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-20T14:09:19.000Z">June 20, 2026 at 2:09 PM</time>
+            <time datetime="2026-06-20T14:09:19.000Z">June 20, 2026 at 9:09 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Supply Chain</span><span class="chip">AI Security</span></div>
           <p class="news-summary">Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet, also known as BlueNoroff. [...]...</p>
@@ -578,7 +581,7 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco..." data-severity="Elevate
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/hackers-exploit-gravity-smtp-wordpress.html" target="_blank" rel="noopener">Hackers Exploit Gravity SMTP WordPress Plugin Bug to Expose API Keys</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-20T09:56:04.000Z">June 20, 2026 at 9:56 AM</time>
+            <time datetime="2026-06-20T09:56:04.000Z">June 20, 2026 at 4:56 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
           <p class="news-summary">Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
@@ -594,7 +597,7 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/klue-oauth-breach-victim-list-grows-as-icarus-hackers-claim-attack/" target="_blank" rel="noopener">Klue OAuth breach victim list grows as Icarus hackers claim attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-19T22:31:04.000Z">June 19, 2026 at 10:31 PM</time>
+            <time datetime="2026-06-19T22:31:04.000Z">June 19, 2026 at 5:31 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <p class="news-summary">Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to customers&#39; Salesforce environments, as the new &quot;...</p>
@@ -653,12 +656,25 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:08:57.142Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:17:01.028Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));
       [sourceFilter, severityFilter, tagFilter, vendorFilter].forEach(function(filter){
         if (filter) filter.addEventListener('change', update);
+      });
+
+      qa('[data-summary-toggle]').forEach(function(toggle){
+        toggle.addEventListener('click', function(){
+          const id = toggle.getAttribute('data-summary-toggle');
+          const summaryPreview = q('#summary-preview-' + id);
+          const summaryFull = q('#summary-full-' + id);
+          const expanded = toggle.getAttribute('aria-expanded') === 'true';
+          if (summaryPreview) summaryPreview.hidden = !expanded;
+          if (summaryFull) summaryFull.hidden = expanded;
+          toggle.setAttribute('aria-expanded', String(!expanded));
+          toggle.textContent = expanded ? 'Show full summary' : 'Show less';
+        });
       });
       update();
 

--- a/index.html
+++ b/index.html
@@ -69,8 +69,11 @@
     .news-meta { color: var(--muted); font-size: 0.85rem; display: flex; gap: 8px; align-items: baseline; }
     .badge-new { color: #16a34a; font-weight: 600; font-size: 0.8rem; }
     .news-summary { margin-top: 8px; color: var(--fg); opacity: 0.9; }
-    .summary-toggle { border: none; background: transparent; color: var(--accent); cursor: pointer; font: inherit; font-size: 0.9rem; margin-top: 2px; padding: 0; }
-    .summary-toggle:hover { text-decoration: underline; }
+    .summary-disclosure { margin-top: 8px; }
+    .summary-toggle { color: var(--fg); cursor: pointer; font: inherit; font-size: 0.95rem; opacity: 0.9; }
+    .summary-action { color: var(--accent); font-size: 0.9rem; margin-left: 6px; white-space: nowrap; }
+    details[open] .summary-ellipsis { display: none; }
+    .summary-toggle:hover .summary-action { text-decoration: underline; }
     .summary-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
     footer { border-top: 1px solid var(--card-border); color: var(--muted); font-size: 0.9rem; padding: 18px 0; margin-top: 22px; }
     @media (max-width: 640px) {
@@ -126,7 +129,7 @@
         <option value="Fortinet">Fortinet</option><option value="GitHub">GitHub</option><option value="Google">Google</option><option value="Microsoft">Microsoft</option><option value="OpenAI">OpenAI</option>
       </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:18:54.900Z">6/23/2026, 1:18:54 PM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:27:03.143Z">6/23/2026, 8:27:03 AM</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
@@ -140,14 +143,16 @@
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/fortibleed-attackers-firewalls-credentials-stealers" target="_blank" rel="noopener">FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 12:34 PM</time>
+            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 7:34 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Identity</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-0">The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-0">The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global campaign....</p>
+            <summary class="summary-toggle" aria-controls="summary-full-0">
+              <span class="summary-preview-text">The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-0">campaign....</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Webinar: Why email security teams are drowning in alerts" data-summary="Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl..." data-severity="Elevated" data-tags="Identity,AI Security" data-vendors="" data-source-signal="Industry media">
@@ -159,14 +164,16 @@
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/webinar-why-email-security-teams-are-drowning-in-alerts/" target="_blank" rel="noopener">Webinar: Why email security teams are drowning in alerts</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 12:12 PM</time>
+            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 7:12 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">AI Security</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-1">Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-1">Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-1">
+              <span class="summary-preview-text">Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-1">help automate detection and response workfl...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Agentic AI: The Weapon That No Longer Needs a Warrior" data-summary="Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media">
@@ -178,14 +185,16 @@
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/agentic-ai-weapon-that-no-longer-needs.html" target="_blank" rel="noopener">Agentic AI: The Weapon That No Longer Needs a Warrior</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 11:30 AM</time>
+            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 6:30 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-2">Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-2">Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-2">
+              <span class="summary-preview-text">Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-2">rifle placed a man&#39;s death a quarter mile...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT" data-summary="Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
@@ -202,18 +211,18 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/malicious-npm-packages-pose-as-postcss.html" target="_blank" rel="noopener">Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 8:54 AM</time>
+            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 3:54 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-3">Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
-
-The list of...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-3">Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
+            <summary class="summary-toggle" aria-controls="summary-full-3">
+              <span class="summary-preview-text">Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
 
-The list of identified packages, is below -
+The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-3">identified packages, is below -
 
 
   aes-...</p>
@@ -228,13 +237,15 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/whatsapp-vbscript-campaign-uses-fake.html" target="_blank" rel="noopener">WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 5:38 AM</time>
+            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 12:38 AM</time>
             <span class="badge-new">NEW</span>
           </div>
-          <p class="news-summary summary-preview" id="summary-preview-4">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-4">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-4">
+              <span class="summary-preview-text">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-4">Remote Monitoring and Management (RMM) softwar...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws" data-summary="OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="OpenAI" data-source-signal="Industry media">
@@ -246,14 +257,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/openai-expands-daybreak-with-gpt-55.html" target="_blank" rel="noopener">OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T03:56:58.000Z">June 23, 2026 at 3:56 AM</time>
+            <time datetime="2026-06-23T03:56:58.000Z">June 22, 2026 at 10:56 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">OpenAI</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-5">OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-5">OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-5">
+              <span class="summary-preview-text">OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-5">intelligence (AI) company announced last mont...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="WhatsApp phishing attack uses fake business docs to hack PCs" data-summary="An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]..." data-severity="Elevated" data-tags="Identity,Malware" data-vendors="" data-source-signal="Industry media">
@@ -265,14 +278,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/whatsapp-phishing-attack-uses-fake-business-docs-to-hack-pcs/" target="_blank" rel="noopener">WhatsApp phishing attack uses fake business docs to hack PCs</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 10:42 PM</time>
+            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 5:42 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">Malware</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-6">An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-6">An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-6">
+              <span class="summary-preview-text">An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-6">access. [...]...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="JaredFromSubway MEV bot hacked in $15 million crypto theft" data-summary="The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media">
@@ -284,13 +299,15 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/jaredfromsubway-mev-bot-hacked-in-15-million-crypto-theft/" target="_blank" rel="noopener">JaredFromSubway MEV bot hacked in $15 million crypto theft</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 9:52 PM</time>
+            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 4:52 PM</time>
             <span class="badge-new">NEW</span>
           </div>
-          <p class="news-summary summary-preview" id="summary-preview-7">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-7">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-7">
+              <span class="summary-preview-text">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-7">creating fake cryptocurrency trading oppor...</p>
           </details>
         </article>
         <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories" data-summary="Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data...." data-severity="Elevated" data-tags="Vulnerability,Exploitation,AI Security" data-vendors="" data-source-signal="Industry media">
@@ -302,14 +319,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/application-security/difytap-bugs-wiretap-ai-chat-histories" target="_blank" rel="noopener">DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 9:14 PM</time>
+            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 4:14 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span><span class="chip">AI Security</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-8">Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-8">Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data....</p>
+            <summary class="summary-toggle" aria-controls="summary-full-8">
+              <span class="summary-preview-text">Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-8">data....</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FFmpeg fixes PixelSmash flaw in widely used video decoder" data-summary="A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media">
@@ -321,14 +340,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/ffmpeg-fixes-pixelsmash-flaw-in-widely-used-video-decoder/" target="_blank" rel="noopener">FFmpeg fixes PixelSmash flaw in widely used video decoder</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 9:05 PM</time>
+            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 4:05 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-9">A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-9">A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-9">
+              <span class="summary-preview-text">A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-9">trigger a denial-of-service  condition in appl...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FortiBleed campaign used custom FortiGate sniffer to steal credentials" data-summary="Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="Fortinet" data-source-signal="Industry media">
@@ -340,14 +361,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/fortibleed-campaign-used-custom-fortigate-sniffer-to-steal-credentials/" target="_blank" rel="noopener">FortiBleed campaign used custom FortiGate sniffer to steal credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 8:01 PM</time>
+            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 3:01 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-10">Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-10">Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-10">
+              <span class="summary-preview-text">Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-10">from compromised firewalls and steal credent...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack" data-summary="Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
@@ -361,14 +384,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/shapedplugin-wordpress-pro-plugins.html" target="_blank" rel="noopener">ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 6:00 PM</time>
+            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 1:00 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-11">Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-11">Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
+            <summary class="summary-toggle" aria-controls="summary-full-11">
+              <span class="summary-preview-text">Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-11">channels and push backdoor code.
 
 &quot;Attack...</p>
           </details>
@@ -382,14 +407,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/microsoft/microsoft-says-windows-11-26h2-is-coming-soon-details-upgrade-process/" target="_blank" rel="noopener">Microsoft says Windows 11 26H2 is coming soon, details upgrade process</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 5:41 PM</time>
+            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 12:41 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-12">Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-12">Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-12">
+              <span class="summary-preview-text">Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-12">using a small enablement package. [...]...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft fixes AutoGen Studio flaw that enabled code execution" data-summary="A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="Microsoft" data-source-signal="Industry media">
@@ -401,14 +428,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/microsoft-fixes-autogen-studio-flaw-that-enabled-code-execution/" target="_blank" rel="noopener">Microsoft fixes AutoGen Studio flaw that enabled code execution</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 5:28 PM</time>
+            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 12:28 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-13">A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-13">A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-13">
+              <span class="summary-preview-text">A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-13">arbitrary commands on its host system sim...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests" data-summary="A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
@@ -420,14 +449,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/29-year-old-squid-proxy-bug-squidbleed.html" target="_blank" rel="noopener">29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 4:29 PM</time>
+            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 11:29 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-14">A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-14">A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-14">
+              <span class="summary-preview-text">A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-14">already allowed to send traffic through the sa...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants" data-summary="Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="GitHub" data-source-signal="Industry media">
@@ -439,14 +470,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/researchers-detail-difytap-flaws-in.html" target="_blank" rel="noopener">Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 4:13 PM</time>
+            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 11:13 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-15">Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars,...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-15">Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-15">
+              <span class="summary-preview-text">Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars,</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-15">that could allow attackers to stealthily...</p>
           </details>
         </article>
         <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign" data-summary="Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker...." data-severity="Monitor" data-tags="" data-vendors="GitHub" data-source-signal="Industry media">
@@ -458,14 +491,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/crypto-heist-fake-reputation-boosting-campaign" target="_blank" rel="noopener">Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 4:10 PM</time>
+            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 11:10 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-16">Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-16">Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker....</p>
+            <summary class="summary-toggle" aria-controls="summary-full-16">
+              <span class="summary-preview-text">Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-16">hijacker....</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="A Glimpse into the “Search Your Target” Market for Stolen Credentials" data-summary="Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
@@ -477,14 +512,16 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/a-glimpse-into-the-search-your-target-market-for-stolen-credentials/" target="_blank" rel="noopener">A Glimpse into the “Search Your Target” Market for Stolen Credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 2:05 PM</time>
+            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 9:05 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-17">Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-17">Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-17">
+              <span class="summary-preview-text">Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-17">searches stolen credential databases for spe...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer" data-summary="Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
@@ -498,14 +535,15 @@ According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Mal
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/new-oxloader-loader-uses-malicious.html" target="_blank" rel="noopener">New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 1:20 PM</time>
-            <span class="badge-new">NEW</span>
+            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 8:20 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Malware</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-18">Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-18">Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
+            <summary class="summary-toggle" aria-controls="summary-full-18">
+              <span class="summary-preview-text">Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-18">OXLOADER.
 
 According to Elastic Security Labs, ...</p>
           </details>
@@ -521,13 +559,15 @@ On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/google-sets-sept-30-deadline-for.html" target="_blank" rel="noopener">Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 12:45 PM</time>
+            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 7:45 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-19">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-19">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app stores are in from the start.
+            <summary class="summary-toggle" aria-controls="summary-full-19">
+              <span class="summary-preview-text">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-19">stores are in from the start.
 
 On that date...</p>
           </details>
@@ -541,13 +581,15 @@ On that date...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/stop-your-legacy-infrastructure-from.html" target="_blank" rel="noopener">Stop Your Legacy Infrastructure from Hijacking Your AI Agents</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 11:58 AM</time>
+            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 6:58 AM</time>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-20">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-20">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-20">
+              <span class="summary-preview-text">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-20">attackers are circumventing AI security progra...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More" data-summary="It’s Monday again.
@@ -561,17 +603,17 @@ This week’s threat list looks painfully familiar: abused integrations, fake to
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/weekly-recap-browser-bugs-edr-killers.html" target="_blank" rel="noopener">⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 10:55 AM</time>
+            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 5:55 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Ransomware</span><span class="chip">Vulnerability</span><span class="chip">Malware</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-21">It’s Monday again.
-
-This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-21">It’s Monday again.
+            <summary class="summary-toggle" aria-controls="summary-full-21">
+              <span class="summary-preview-text">It’s Monday again.
 
-This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down security tools, and mobile malware asking...</p>
+This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-21">security tools, and mobile malware asking...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices" data-summary="Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
@@ -585,13 +627,15 @@ The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" 
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/canadas-spy-agency-used-first-of-its.html" target="_blank" rel="noopener">Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 9:11 AM</time>
+            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 4:11 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-22">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-22">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
+            <summary class="summary-toggle" aria-controls="summary-full-22">
+              <span class="summary-preview-text">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-22">foreign-run botnets.
 
 The Federal Court released a ...</p>
           </details>
@@ -605,13 +649,15 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/arystinger-malware-infects-4300-legacy.html" target="_blank" rel="noopener">AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 6:57 AM</time>
+            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 1:57 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-23">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-23">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-23">
+              <span class="summary-preview-text">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-23">in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific" data-summary="A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne..." data-severity="Critical" data-tags="Ransomware,Identity,AI Security" data-vendors="" data-source-signal="Industry media">
@@ -623,13 +669,15 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/interpol-warns-phishing-ransomware-and.html" target="_blank" rel="noopener">INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 6:06 AM</time>
+            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 1:06 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span><span class="chip">Identity</span><span class="chip">AI Security</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-24">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-24">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-24">
+              <span class="summary-preview-text">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-24">penetration, new technologies, organized criminal ne...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="AryStinger botnet infected thousands of D-Link routers worldwide" data-summary="A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media">
@@ -641,13 +689,15 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/arystinger-botnet-infected-thousands-of-d-link-routers-worldwide/" target="_blank" rel="noopener">AryStinger botnet infected thousands of D-Link routers worldwide</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-21T14:14:22.000Z">June 21, 2026 at 2:14 PM</time>
+            <time datetime="2026-06-21T14:14:22.000Z">June 21, 2026 at 9:14 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-25">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic....</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-25">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-25">
+              <span class="summary-preview-text">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic.</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-25">[...]...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="New Prinz Eugen ransomware prioritizes recent files for encryption" data-summary="A new ransomware operation named &#39;Prinz Eugen&#39; prioritizes recently modified files for encryption and leaves no ransom note on the system. [...]..." data-severity="Critical" data-tags="Ransomware" data-vendors="" data-source-signal="Industry media">
@@ -659,7 +709,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/new-prinz-eugen-ransomware-prioritizes-recent-files-for-encryption/" target="_blank" rel="noopener">New Prinz Eugen ransomware prioritizes recent files for encryption</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-20T15:23:46.000Z">June 20, 2026 at 3:23 PM</time>
+            <time datetime="2026-06-20T15:23:46.000Z">June 20, 2026 at 10:23 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span></div>
           <p class="news-summary">A new ransomware operation named &#39;Prinz Eugen&#39; prioritizes recently modified files for encryption and leaves no ransom note on the system. [...]...</p>
@@ -673,13 +723,15 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/microsoft-links-mastra-ai-supply-chain-attack-to-north-korean-hackers/" target="_blank" rel="noopener">Microsoft links Mastra AI supply chain attack to North Korean hackers</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-20T14:09:19.000Z">June 20, 2026 at 2:09 PM</time>
+            <time datetime="2026-06-20T14:09:19.000Z">June 20, 2026 at 9:09 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Supply Chain</span><span class="chip">AI Security</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-27">Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet,...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-27">Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet, also known as BlueNoroff. [...]...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-27">
+              <span class="summary-preview-text">Microsoft has attributed a recent Mastra AI supply chain attack that compromised more than 140 npm packages to the North Korean hacking group Sapphire Sleet,</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-27">also known as BlueNoroff. [...]...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Hackers Exploit Gravity SMTP WordPress Plugin Bug to Expose API Keys" data-summary="Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
@@ -693,17 +745,17 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco..." data-severity="Elevate
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/hackers-exploit-gravity-smtp-wordpress.html" target="_blank" rel="noopener">Hackers Exploit Gravity SMTP WordPress Plugin Bug to Expose API Keys</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-20T09:56:04.000Z">June 20, 2026 at 9:56 AM</time>
+            <time datetime="2026-06-20T09:56:04.000Z">June 20, 2026 at 4:56 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-28">Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
-
-The...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-28">Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
+            <summary class="summary-toggle" aria-controls="summary-full-28">
+              <span class="summary-preview-text">Threat actors are exploiting a recently patched security flaw impacting Gravity SMTP, a WordPress plugin that&#39;s installed on about 100,000 sites.
 
-The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
+The</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-28">vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Klue OAuth breach victim list grows as Icarus hackers claim attack" data-summary="Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to customers&#39; Salesforce environments, as the new &quot;..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
@@ -715,13 +767,15 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/klue-oauth-breach-victim-list-grows-as-icarus-hackers-claim-attack/" target="_blank" rel="noopener">Klue OAuth breach victim list grows as Icarus hackers claim attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-19T22:31:04.000Z">June 19, 2026 at 10:31 PM</time>
+            <time datetime="2026-06-19T22:31:04.000Z">June 19, 2026 at 5:31 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
-          <p class="news-summary summary-preview" id="summary-preview-29">Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to...</p>
           <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-29">Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to customers&#39; Salesforce environments, as the new &quot;...</p>
+            <summary class="summary-toggle" aria-controls="summary-full-29">
+              <span class="summary-preview-text">Market intelligence platform Klue has publicly confirmed a recent security incident that allowed threat actors to steal OAuth tokens used to connect to</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-29">customers&#39; Salesforce environments, as the new &quot;...</p>
           </details>
         </article>
     </div>
@@ -778,7 +832,7 @@ The vulnerability, tracked as CVE-2026-4020 (CVSS sco...</p>
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:18:54.900Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:27:03.143Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
     .summary-toggle { color: var(--fg); cursor: pointer; font: inherit; font-size: 0.95rem; opacity: 0.9; }
     .summary-action { color: var(--accent); font-size: 0.9rem; margin-left: 6px; white-space: nowrap; }
     details[open] .summary-ellipsis { display: none; }
+    details[open] .summary-action { display: none; }
     .summary-toggle:hover .summary-action { text-decoration: underline; }
     .summary-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
     footer { border-top: 1px solid var(--card-border); color: var(--muted); font-size: 0.9rem; padding: 18px 0; margin-top: 22px; }
@@ -129,7 +130,7 @@
         <option value="Fortinet">Fortinet</option><option value="GitHub">GitHub</option><option value="Google">Google</option><option value="Microsoft">Microsoft</option><option value="OpenAI">OpenAI</option>
       </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T13:27:03.143Z">6/23/2026, 8:27:03 AM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T14:07:50.973Z">6/23/2026, 9:07:51 AM</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
@@ -513,7 +514,6 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/a-glimpse-into-the-search-your-target-market-for-stolen-credentials/" target="_blank" rel="noopener">A Glimpse into the “Search Your Target” Market for Stolen Credentials</a></h2>
           <div class="news-meta">
             <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 9:05 AM</time>
-            <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <details class="summary-disclosure">
@@ -832,7 +832,7 @@ The</span><span class="summary-ellipsis" aria-hidden="true">...</span>
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T13:27:03.143Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T14:07:50.973Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -155,8 +155,10 @@ function renderSummary(summary, index) {
 
   const safePreview = escapeHtml(getSummaryPreview(summary));
   return `<p class="news-summary summary-preview" id="summary-preview-${index}">${safePreview}</p>
-          <p class="news-summary summary-full" id="summary-full-${index}" hidden>${safeSummary}</p>
-          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-${index}" data-summary-toggle="${index}">Show full summary</button>`;
+          <details class="summary-disclosure">
+            <summary class="summary-toggle">Show full summary</summary>
+            <p class="news-summary summary-full" id="summary-full-${index}">${safeSummary}</p>
+          </details>`;
 }
 
 function renderArticleCard(article, index = 0) {
@@ -426,18 +428,6 @@ function generateHTML(newsItems) {
         if (filter) filter.addEventListener('change', update);
       });
 
-      qa('[data-summary-toggle]').forEach(function(toggle){
-        toggle.addEventListener('click', function(){
-          const id = toggle.getAttribute('data-summary-toggle');
-          const summaryPreview = q('#summary-preview-' + id);
-          const summaryFull = q('#summary-full-' + id);
-          const expanded = toggle.getAttribute('aria-expanded') === 'true';
-          if (summaryPreview) summaryPreview.hidden = !expanded;
-          if (summaryFull) summaryFull.hidden = expanded;
-          toggle.setAttribute('aria-expanded', String(!expanded));
-          toggle.textContent = expanded ? 'Show full summary' : 'Show less';
-        });
-      });
       update();
 
       function debounce(fn, wait){ let t; return function(){ clearTimeout(t); t=setTimeout(fn, wait); } }

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -120,7 +120,7 @@ function renderSelectOptions(values) {
     .join('');
 }
 
-const SUMMARY_PREVIEW_LENGTH = 220;
+const SUMMARY_PREVIEW_LENGTH = 160;
 
 function getSummaryPreview(summary) {
   if (summary.length <= SUMMARY_PREVIEW_LENGTH) {
@@ -129,7 +129,7 @@ function getSummaryPreview(summary) {
 
   const preview = summary.slice(0, SUMMARY_PREVIEW_LENGTH);
   const lastSpace = preview.lastIndexOf(' ');
-  const trimmed = preview.slice(0, lastSpace > 160 ? lastSpace : SUMMARY_PREVIEW_LENGTH).trim();
+  const trimmed = preview.slice(0, lastSpace > 120 ? lastSpace : SUMMARY_PREVIEW_LENGTH).trim();
   return `${trimmed}...`;
 }
 

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -324,6 +324,7 @@ function generateHTML(newsItems) {
     .summary-toggle { color: var(--fg); cursor: pointer; font: inherit; font-size: 0.95rem; opacity: 0.9; }
     .summary-action { color: var(--accent); font-size: 0.9rem; margin-left: 6px; white-space: nowrap; }
     details[open] .summary-ellipsis { display: none; }
+    details[open] .summary-action { display: none; }
     .summary-toggle:hover .summary-action { text-decoration: underline; }
     .summary-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
     footer { border-top: 1px solid var(--card-border); color: var(--muted); font-size: 0.9rem; padding: 18px 0; margin-top: 22px; }

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -121,16 +121,28 @@ function renderSelectOptions(values) {
 }
 
 const SUMMARY_PREVIEW_LENGTH = 160;
+const SUMMARY_WORD_BOUNDARY_MIN = 120;
 
 function getSummaryPreview(summary) {
+  const parts = getSummaryParts(summary);
+  return parts ? `${parts.preview}...` : summary;
+}
+
+function getSummaryParts(summary) {
   if (summary.length <= SUMMARY_PREVIEW_LENGTH) {
-    return summary;
+    return null;
   }
 
   const preview = summary.slice(0, SUMMARY_PREVIEW_LENGTH);
   const lastSpace = preview.lastIndexOf(' ');
-  const trimmed = preview.slice(0, lastSpace > 120 ? lastSpace : SUMMARY_PREVIEW_LENGTH).trim();
-  return `${trimmed}...`;
+  const previewEnd = lastSpace > SUMMARY_WORD_BOUNDARY_MIN ? lastSpace : SUMMARY_PREVIEW_LENGTH;
+  const previewText = preview.slice(0, previewEnd).trim();
+  const remainder = summary.slice(previewText.length).trimStart();
+
+  return {
+    preview: previewText,
+    remainder,
+  };
 }
 
 function formatArticleDate(value) {
@@ -153,11 +165,15 @@ function renderSummary(summary, index) {
     return `<p class="news-summary">${safeSummary}</p>`;
   }
 
-  const safePreview = escapeHtml(getSummaryPreview(summary));
-  return `<p class="news-summary summary-preview" id="summary-preview-${index}">${safePreview}</p>
-          <details class="summary-disclosure">
-            <summary class="summary-toggle">Show full summary</summary>
-            <p class="news-summary summary-full" id="summary-full-${index}">${safeSummary}</p>
+  const summaryParts = getSummaryParts(summary);
+  const safePreview = escapeHtml(summaryParts.preview);
+  const safeRemainder = escapeHtml(summaryParts.remainder);
+  return `<details class="summary-disclosure">
+            <summary class="summary-toggle" aria-controls="summary-full-${index}">
+              <span class="summary-preview-text">${safePreview}</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-${index}">${safeRemainder}</p>
           </details>`;
 }
 
@@ -304,8 +320,11 @@ function generateHTML(newsItems) {
     .news-meta { color: var(--muted); font-size: 0.85rem; display: flex; gap: 8px; align-items: baseline; }
     .badge-new { color: #16a34a; font-weight: 600; font-size: 0.8rem; }
     .news-summary { margin-top: 8px; color: var(--fg); opacity: 0.9; }
-    .summary-toggle { border: none; background: transparent; color: var(--accent); cursor: pointer; font: inherit; font-size: 0.9rem; margin-top: 2px; padding: 0; }
-    .summary-toggle:hover { text-decoration: underline; }
+    .summary-disclosure { margin-top: 8px; }
+    .summary-toggle { color: var(--fg); cursor: pointer; font: inherit; font-size: 0.95rem; opacity: 0.9; }
+    .summary-action { color: var(--accent); font-size: 0.9rem; margin-left: 6px; white-space: nowrap; }
+    details[open] .summary-ellipsis { display: none; }
+    .summary-toggle:hover .summary-action { text-decoration: underline; }
     .summary-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
     footer { border-top: 1px solid var(--card-border); color: var(--muted); font-size: 0.9rem; padding: 18px 0; margin-top: 22px; }
     @media (max-width: 640px) {

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -120,6 +120,19 @@ function renderSelectOptions(values) {
     .join('');
 }
 
+const SUMMARY_PREVIEW_LENGTH = 220;
+
+function getSummaryPreview(summary) {
+  if (summary.length <= SUMMARY_PREVIEW_LENGTH) {
+    return summary;
+  }
+
+  const preview = summary.slice(0, SUMMARY_PREVIEW_LENGTH);
+  const lastSpace = preview.lastIndexOf(' ');
+  const trimmed = preview.slice(0, lastSpace > 160 ? lastSpace : SUMMARY_PREVIEW_LENGTH).trim();
+  return `${trimmed}...`;
+}
+
 function formatArticleDate(value) {
   return new Intl.DateTimeFormat('en-US', {
     month: 'long',
@@ -130,7 +143,23 @@ function formatArticleDate(value) {
   }).format(new Date(value));
 }
 
-function renderArticleCard(article) {
+function renderSummary(summary, index) {
+  if (!summary) {
+    return '';
+  }
+
+  const safeSummary = escapeHtml(summary);
+  if (summary.length <= SUMMARY_PREVIEW_LENGTH) {
+    return `<p class="news-summary">${safeSummary}</p>`;
+  }
+
+  const safePreview = escapeHtml(getSummaryPreview(summary));
+  return `<p class="news-summary summary-preview" id="summary-preview-${index}">${safePreview}</p>
+          <p class="news-summary summary-full" id="summary-full-${index}" hidden>${safeSummary}</p>
+          <button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-${index}" data-summary-toggle="${index}">Show full summary</button>`;
+}
+
+function renderArticleCard(article, index = 0) {
   const articleLink = safeArticleLink(article.link);
   const facets = deriveArticleFacets(article);
   const hostname = (() => {
@@ -149,7 +178,6 @@ function renderArticleCard(article) {
   const safeHostAttr = escapeAttribute(hostname);
   const safeTitle = escapeHtml(article.title);
   const safeTitleAttr = escapeAttribute(article.title);
-  const safeSummary = escapeHtml(article.summary);
   const safeSummaryAttr = escapeAttribute(article.summary);
   const safeLink = escapeAttribute(articleLink);
   const safeSeverity = escapeHtml(facets.severity);
@@ -164,6 +192,7 @@ function renderArticleCard(article) {
   const hostChip = hostname ? `\n            <span class="chip">${safeHost}</span>` : '';
   const newBadge = isNew ? `\n            <span class="badge-new">NEW</span>` : '';
   const facetRow = (vendorChips || tagChips) ? `\n          <div class="facet-row">${vendorChips}${tagChips}</div>` : '';
+  const summary = renderSummary(article.summary, index);
 
   return `
         <article class="news-item" data-source="${safeSourceAttr}" data-host="${safeHostAttr}" data-title="${safeTitleAttr}" data-summary="${safeSummaryAttr}" data-severity="${safeSeverityAttr}" data-tags="${safeTagsAttr}" data-vendors="${safeVendorsAttr}" data-source-signal="${safeSourceSignalAttr}">
@@ -176,7 +205,7 @@ function renderArticleCard(article) {
           <div class="news-meta">
             <time datetime="${dateIso}">${dateText}</time>${newBadge}
           </div>${facetRow}
-          ${article.summary ? `<p class="news-summary">${safeSummary}</p>` : ''}
+          ${summary}
         </article>`;
 }
 
@@ -199,7 +228,7 @@ function generateHTML(newsItems) {
   const vendorOptions = renderSelectOptions(filterOptions.vendors);
   const nowIso = new Date().toISOString();
   const articleCards = newsItems.length > 0
-    ? newsItems.map(renderArticleCard).join('')
+    ? newsItems.map((article, index) => renderArticleCard(article, index)).join('')
     : renderEmptyState();
 
   return `
@@ -273,6 +302,9 @@ function generateHTML(newsItems) {
     .news-meta { color: var(--muted); font-size: 0.85rem; display: flex; gap: 8px; align-items: baseline; }
     .badge-new { color: #16a34a; font-weight: 600; font-size: 0.8rem; }
     .news-summary { margin-top: 8px; color: var(--fg); opacity: 0.9; }
+    .summary-toggle { border: none; background: transparent; color: var(--accent); cursor: pointer; font: inherit; font-size: 0.9rem; margin-top: 2px; padding: 0; }
+    .summary-toggle:hover { text-decoration: underline; }
+    .summary-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
     footer { border-top: 1px solid var(--card-border); color: var(--muted); font-size: 0.9rem; padding: 18px 0; margin-top: 22px; }
     @media (max-width: 640px) {
       .container { padding: 16px; }
@@ -393,6 +425,19 @@ function generateHTML(newsItems) {
       [sourceFilter, severityFilter, tagFilter, vendorFilter].forEach(function(filter){
         if (filter) filter.addEventListener('change', update);
       });
+
+      qa('[data-summary-toggle]').forEach(function(toggle){
+        toggle.addEventListener('click', function(){
+          const id = toggle.getAttribute('data-summary-toggle');
+          const summaryPreview = q('#summary-preview-' + id);
+          const summaryFull = q('#summary-full-' + id);
+          const expanded = toggle.getAttribute('aria-expanded') === 'true';
+          if (summaryPreview) summaryPreview.hidden = !expanded;
+          if (summaryFull) summaryFull.hidden = expanded;
+          toggle.setAttribute('aria-expanded', String(!expanded));
+          toggle.textContent = expanded ? 'Show full summary' : 'Show less';
+        });
+      });
       update();
 
       function debounce(fn, wait){ let t; return function(){ clearTimeout(t); t=setTimeout(fn, wait); } }
@@ -409,6 +454,7 @@ module.exports = {
   escapeHtml,
   formatArticleDate,
   generateHTML,
+  getSummaryPreview,
   renderArticleCard,
   safeArticleLink,
 };

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -342,13 +342,38 @@ test('generateHTML renders long summaries as accessible expandable content', () 
     },
   ]);
 
-  assert.match(html, /<p class="news-summary summary-preview" id="summary-preview-0">/);
   assert.match(html, /<details class="summary-disclosure">/);
-  assert.match(html, /<summary class="summary-toggle">Show full summary<\/summary>/);
+  assert.match(html, /<summary class="summary-toggle" aria-controls="summary-full-0">/);
+  assert.match(html, /<span class="summary-preview-text">Security teams should prioritize exposed VPN appliances/);
+  assert.match(html, /<span class="summary-action">Show full summary<\/span>/);
   assert.match(html, /<p class="news-summary summary-full" id="summary-full-0">/);
+  assert.doesNotMatch(html, /<p class="news-summary summary-preview"/);
   assert.doesNotMatch(html, /data-summary-toggle/);
   assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
   assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+});
+
+test('generateHTML splits expanded summary content without duplicating the preview', () => {
+  const previewText = 'Security teams should prioritize exposed VPN appliances and patch externally managed edge devices before broad scanning starts';
+  const summary = `${previewText} because attackers are chaining the flaw with stolen credentials across incident response cases.`;
+  const html = generateHTML([
+    {
+      title: 'VPN exploitation campaign expands',
+      link: 'https://example.com/vpn-exploitation',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example Security',
+      summary,
+    },
+  ]);
+
+  const previewMatch = html.match(/<span class="summary-preview-text">([^<]+)<\/span>/);
+  const remainderMatch = html.match(/<p class="news-summary summary-full" id="summary-full-0">([^<]+)<\/p>/);
+
+  assert.ok(previewMatch);
+  assert.ok(remainderMatch);
+  assert.ok(summary.startsWith(previewMatch[1]));
+  assert.ok(summary.endsWith(remainderMatch[1]));
+  assert.ok(!remainderMatch[1].startsWith(previewMatch[1]));
 });
 
 test('generateHTML expands production-shaped fetched summaries', () => {
@@ -365,9 +390,9 @@ test('generateHTML expands production-shaped fetched summaries', () => {
     },
   ]);
 
-  assert.match(html, /<p class="news-summary summary-preview" id="summary-preview-0">/);
   assert.match(html, /<details class="summary-disclosure">/);
-  assert.match(html, /<summary class="summary-toggle">Show full summary<\/summary>/);
+  assert.match(html, /<summary class="summary-toggle" aria-controls="summary-full-0">/);
+  assert.match(html, /<span class="summary-preview-text">Security teams should prioritize exposed VPN appliances/);
   assert.match(html, /<p class="news-summary summary-full" id="summary-full-0">/);
 });
 

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -346,6 +346,7 @@ test('generateHTML renders long summaries as accessible expandable content', () 
   assert.match(html, /<summary class="summary-toggle" aria-controls="summary-full-0">/);
   assert.match(html, /<span class="summary-preview-text">Security teams should prioritize exposed VPN appliances/);
   assert.match(html, /<span class="summary-action">Show full summary<\/span>/);
+  assert.match(html, /details\[open\] \.summary-action \{ display: none; \}/);
   assert.match(html, /<p class="news-summary summary-full" id="summary-full-0">/);
   assert.doesNotMatch(html, /<p class="news-summary summary-preview"/);
   assert.doesNotMatch(html, /data-summary-toggle/);

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -329,3 +329,40 @@ test('generateHTML renders facet filter controls and empty filtered state', () =
   assert.match(html, /split\(','\)\.filter\(Boolean\)\.includes\(tag\)/);
   assert.match(html, /split\(','\)\.filter\(Boolean\)\.includes\(vendor\)/);
 });
+
+test('generateHTML renders long summaries as accessible expandable content', () => {
+  const longSummary = `${'Security teams should prioritize exposed VPN appliances. '.repeat(6)}<script>alert(1)</script>`;
+  const html = generateHTML([
+    {
+      title: 'VPN exploitation campaign expands',
+      link: 'https://example.com/vpn-exploitation',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example Security',
+      summary: longSummary,
+    },
+  ]);
+
+  assert.match(html, /<p class="news-summary summary-preview" id="summary-preview-0">/);
+  assert.match(html, /<p class="news-summary summary-full" id="summary-full-0" hidden>/);
+  assert.match(html, /<button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-0" data-summary-toggle="0">Show full summary<\/button>/);
+  assert.match(html, /summaryFull\.hidden = expanded/);
+  assert.match(html, /toggle\.setAttribute\('aria-expanded', String\(!expanded\)\)/);
+  assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+});
+
+test('generateHTML leaves short summaries as plain escaped content', () => {
+  const html = generateHTML([
+    {
+      title: 'Brief advisory',
+      link: 'https://example.com/brief-advisory',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example Security',
+      summary: 'Patch exposed systems <quickly>.',
+    },
+  ]);
+
+  assert.match(html, /<p class="news-summary">Patch exposed systems &lt;quickly&gt;\.<\/p>/);
+  assert.doesNotMatch(html, /<button class="summary-toggle"/);
+  assert.doesNotMatch(html, /<p class="news-summary summary-full"/);
+});

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -343,10 +343,10 @@ test('generateHTML renders long summaries as accessible expandable content', () 
   ]);
 
   assert.match(html, /<p class="news-summary summary-preview" id="summary-preview-0">/);
-  assert.match(html, /<p class="news-summary summary-full" id="summary-full-0" hidden>/);
-  assert.match(html, /<button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-0" data-summary-toggle="0">Show full summary<\/button>/);
-  assert.match(html, /summaryFull\.hidden = expanded/);
-  assert.match(html, /toggle\.setAttribute\('aria-expanded', String\(!expanded\)\)/);
+  assert.match(html, /<details class="summary-disclosure">/);
+  assert.match(html, /<summary class="summary-toggle">Show full summary<\/summary>/);
+  assert.match(html, /<p class="news-summary summary-full" id="summary-full-0">/);
+  assert.doesNotMatch(html, /data-summary-toggle/);
   assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
   assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
 });
@@ -366,8 +366,9 @@ test('generateHTML expands production-shaped fetched summaries', () => {
   ]);
 
   assert.match(html, /<p class="news-summary summary-preview" id="summary-preview-0">/);
-  assert.match(html, /<p class="news-summary summary-full" id="summary-full-0" hidden>/);
-  assert.match(html, /<button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-0" data-summary-toggle="0">Show full summary<\/button>/);
+  assert.match(html, /<details class="summary-disclosure">/);
+  assert.match(html, /<summary class="summary-toggle">Show full summary<\/summary>/);
+  assert.match(html, /<p class="news-summary summary-full" id="summary-full-0">/);
 });
 
 test('generateHTML leaves short summaries as plain escaped content', () => {
@@ -382,6 +383,6 @@ test('generateHTML leaves short summaries as plain escaped content', () => {
   ]);
 
   assert.match(html, /<p class="news-summary">Patch exposed systems &lt;quickly&gt;\.<\/p>/);
-  assert.doesNotMatch(html, /<button class="summary-toggle"/);
+  assert.doesNotMatch(html, /<details class="summary-disclosure"/);
   assert.doesNotMatch(html, /<p class="news-summary summary-full"/);
 });

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -351,6 +351,25 @@ test('generateHTML renders long summaries as accessible expandable content', () 
   assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
 });
 
+test('generateHTML expands production-shaped fetched summaries', () => {
+  const fetchedSummary = `${'Security teams should prioritize exposed VPN appliances and review incident timelines. '.repeat(3).slice(0, 200)}...`;
+  assert.equal(fetchedSummary.length, 203);
+
+  const html = generateHTML([
+    {
+      title: 'Fetched summary advisory',
+      link: 'https://example.com/fetched-summary-advisory',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example Security',
+      summary: fetchedSummary,
+    },
+  ]);
+
+  assert.match(html, /<p class="news-summary summary-preview" id="summary-preview-0">/);
+  assert.match(html, /<p class="news-summary summary-full" id="summary-full-0" hidden>/);
+  assert.match(html, /<button class="summary-toggle" type="button" aria-expanded="false" aria-controls="summary-full-0" data-summary-toggle="0">Show full summary<\/button>/);
+});
+
 test('generateHTML leaves short summaries as plain escaped content', () => {
   const html = generateHTML([
     {


### PR DESCRIPTION
## Summary
- Add previews and native expand controls for long article summaries.
- Keep short summaries as plain escaped text.
- Preserve escaped full-summary content in generated cards.

## Validation
- npm test
- git diff --check