### PR TITLE
Add downstream handoff cues

### DIFF
--- a/config/news-sources.json
+++ b/config/news-sources.json
@@ -33,7 +33,7 @@
   ],
   "settings": {
     "maxNewsItems": 30,
-    "lastUpdated": "2026-06-23T14:15:42.555Z",
+    "lastUpdated": "2026-06-23T14:32:08.805Z",
     "testTrigger": true,
     "manualTrigger": "2025-09-19T13:55:00.000Z",
     "sortMode": "recent"

--- a/feed-info.json
+++ b/feed-info.json
@@ -9,5 +9,5 @@
     "Bleeping Computer",
     "Dark Reading"
   ],
-  "lastUpdated": "2026-06-23T14:15:42.619Z"
+  "lastUpdated": "2026-06-23T14:32:08.866Z"
 }

--- a/feed.xml
+++ b/feed.xml
@@ -9,12 +9,23 @@
             <link>https://ricomanifesto.github.io/SentryDigest/</link>
         </image>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Tue, 23 Jun 2026 14:15:42 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 23 Jun 2026 14:32:08 GMT</lastBuildDate>
         <atom:link href="https://ricomanifesto.github.io/SentryDigest/feed.xml" rel="self" type="application/rss+xml"/>
-        <pubDate>Tue, 23 Jun 2026 14:15:42 GMT</pubDate>
+        <pubDate>Tue, 23 Jun 2026 14:32:08 GMT</pubDate>
         <language><![CDATA[en]]></language>
         <ttl>180</ttl>
         <comment>News aggregated from: Krebs on Security, The Hacker News, Threatpost, Bleeping Computer, Dark Reading</comment>
+        <item>
+            <title><![CDATA[GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns]]></title>
+            <description><![CDATA[GitHub is moving to strengthen software supply chain security by updating "actions/checkout" to block pwn request attacks that exploit the risky use of the "pull_request_target workflow" trigger to ru...]]></description>
+            <link>https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html</link>
+            <guid isPermaLink="false">https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html</guid>
+            <category><![CDATA[The Hacker News]]></category>
+            <dc:creator><![CDATA[The Hacker News]]></dc:creator>
+            <pubDate>Tue, 23 Jun 2026 14:22:03 GMT</pubDate>
+            <dc:source>The Hacker News</dc:source>
+            <dc:date>2026-06-23</dc:date>
+        </item>
         <item>
             <title><![CDATA[The Exploit Doesn't Exist. You Can Still Prove It Works Against You]]></title>
             <description><![CDATA[Attackers can now weaponize newly disclosed vulnerabilities far faster than most organizations can patch them. Picus Security explains how security teams can validate exploitability before a public ex...]]></description>
@@ -348,17 +359,6 @@ The Federal Court released a ...]]></description>
             <pubDate>Mon, 22 Jun 2026 06:06:53 GMT</pubDate>
             <dc:source>The Hacker News</dc:source>
             <dc:date>2026-06-22</dc:date>
-        </item>
-        <item>
-            <title><![CDATA[AryStinger botnet infected thousands of D-Link routers worldwide]]></title>
-            <description><![CDATA[A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]...]]></description>
-            <link>https://www.bleepingcomputer.com/news/security/arystinger-botnet-infected-thousands-of-d-link-routers-worldwide/</link>
-            <guid isPermaLink="false">https://www.bleepingcomputer.com/news/security/arystinger-botnet-infected-thousands-of-d-link-routers-worldwide/</guid>
-            <category><![CDATA[Bleeping Computer]]></category>
-            <dc:creator><![CDATA[Bleeping Computer]]></dc:creator>
-            <pubDate>Sun, 21 Jun 2026 14:14:22 GMT</pubDate>
-            <dc:source>Bleeping Computer</dc:source>
-            <dc:date>2026-06-21</dc:date>
         </item>
     </channel>
 </rss>

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
         </div>
         <select id="sourceFilter" class="select" aria-label="Filter by source">
           <option value="">All sources</option>
-          <option value="Bleeping Computer">Bleeping Computer</option><option value="Dark Reading">Dark Reading</option><option value="The Hacker News">The Hacker News</option>
+          <option value="The Hacker News">The Hacker News</option><option value="Bleeping Computer">Bleeping Computer</option><option value="Dark Reading">Dark Reading</option>
         </select>
         <a class="btn" href="./feed.xml">RSS</a>
         <button id="themeToggle" class="btn" aria-label="Toggle theme">Theme</button>
@@ -132,11 +132,33 @@
         <option value="Fortinet">Fortinet</option><option value="GitHub">GitHub</option><option value="Google">Google</option><option value="Microsoft">Microsoft</option><option value="OpenAI">OpenAI</option>
       </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T14:30:06.072Z">6/23/2026, 9:30:06 AM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T14:32:08.790Z">6/23/2026, 2:32:08 PM</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
       
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns" data-summary="GitHub is moving to strengthen software supply chain security by updating &quot;actions/checkout&quot; to block pwn request attacks that exploit the risky use of the &quot;pull_request_target workflow&quot; trigger to ru..." data-severity="Elevated" data-tags="Exploitation,Supply Chain" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
+          <div class="chips">
+            <span class="severity severity-elevated">Elevated</span>
+            <span class="chip"><span class="dot"></span>The Hacker News</span>
+            <span class="chip">thehackernews.com</span>
+            <span class="chip">Industry media</span>
+          </div>
+          <h2 class="news-title"><a href="https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html" target="_blank" rel="noopener">GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns</a></h2>
+          <div class="news-meta">
+            <time datetime="2026-06-23T14:22:03.000Z">June 23, 2026 at 2:22 PM</time>
+            <span class="badge-new">NEW</span>
+          </div>
+          <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Exploitation</span><span class="chip">Supply Chain</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
+          <details class="summary-disclosure">
+            <summary class="summary-toggle" aria-controls="summary-full-0">
+              <span class="summary-preview-text">GitHub is moving to strengthen software supply chain security by updating &quot;actions/checkout&quot; to block pwn request attacks that exploit the risky use of the</span><span class="summary-ellipsis" aria-hidden="true">...</span>
+              <span class="summary-action">Show full summary</span>
+            </summary>
+            <p class="news-summary summary-full" id="summary-full-0">&quot;pull_request_target workflow&quot; trigger to ru...</p>
+          </details>
+        </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="The Exploit Doesn&#39;t Exist. You Can Still Prove It Works Against You" data-summary="Attackers can now weaponize newly disclosed vulnerabilities far faster than most organizations can patch them. Picus Security explains how security teams can validate exploitability before a public ex..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
@@ -146,17 +168,17 @@
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/the-exploit-doesnt-exist-you-can-still-prove-it-works-against-you/" target="_blank" rel="noopener">The Exploit Doesn&#39;t Exist. You Can Still Prove It Works Against You</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T14:01:11.000Z">June 23, 2026 at 9:01 AM</time>
+            <time datetime="2026-06-23T14:01:11.000Z">June 23, 2026 at 2:01 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-0">
+            <summary class="summary-toggle" aria-controls="summary-full-1">
               <span class="summary-preview-text">Attackers can now weaponize newly disclosed vulnerabilities far faster than most organizations can patch them. Picus Security explains how security teams can</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-0">validate exploitability before a public ex...</p>
+            <p class="news-summary summary-full" id="summary-full-1">validate exploitability before a public ex...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="LastPass confirms data breach in Klue supply chain attack" data-summary="LastPass announced that hackers accessed customer data from its Salesforce environment after stealing the company&#39;s OAuth tokens in the Klue supply chain attack earlier this month. [...]..." data-severity="Critical" data-tags="Data Breach,Identity,Supply Chain" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
@@ -168,17 +190,17 @@
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/lastpass-confirms-data-breach-in-klue-supply-chain-attack/" target="_blank" rel="noopener">LastPass confirms data breach in Klue supply chain attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T13:58:25.000Z">June 23, 2026 at 8:58 AM</time>
+            <time datetime="2026-06-23T13:58:25.000Z">June 23, 2026 at 1:58 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span><span class="chip">Supply Chain</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-1">
+            <summary class="summary-toggle" aria-controls="summary-full-2">
               <span class="summary-preview-text">LastPass announced that hackers accessed customer data from its Salesforce environment after stealing the company&#39;s OAuth tokens in the Klue supply chain</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-1">attack earlier this month. [...]...</p>
+            <p class="news-summary summary-full" id="summary-full-2">attack earlier this month. [...]...</p>
           </details>
         </article>
         <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="SocGholish Takedown Highlights Malicious TDS Threats" data-summary="SocGholish uses traffic distribution systems (TDSs) to provide initial access into victims&#39; networks for cybercrime groups such as the notorious Evil Corp...." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
@@ -190,7 +212,7 @@
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyber-risk/socgholish-takedown-malicious-tds-threats" target="_blank" rel="noopener">SocGholish Takedown Highlights Malicious TDS Threats</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T13:51:33.000Z">June 23, 2026 at 8:51 AM</time>
+            <time datetime="2026-06-23T13:51:33.000Z">June 23, 2026 at 1:51 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -205,17 +227,17 @@
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/fortibleed-attackers-firewalls-credentials-stealers" target="_blank" rel="noopener">FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 7:34 AM</time>
+            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 12:34 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Identity</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-3">
+            <summary class="summary-toggle" aria-controls="summary-full-4">
               <span class="summary-preview-text">The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-3">campaign....</p>
+            <p class="news-summary summary-full" id="summary-full-4">campaign....</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Webinar: Why email security teams are drowning in alerts" data-summary="Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl..." data-severity="Elevated" data-tags="Identity,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
@@ -227,17 +249,17 @@
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/webinar-why-email-security-teams-are-drowning-in-alerts/" target="_blank" rel="noopener">Webinar: Why email security teams are drowning in alerts</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 7:12 AM</time>
+            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 12:12 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-4">
+            <summary class="summary-toggle" aria-controls="summary-full-5">
               <span class="summary-preview-text">Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-4">help automate detection and response workfl...</p>
+            <p class="news-summary summary-full" id="summary-full-5">help automate detection and response workfl...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Agentic AI: The Weapon That No Longer Needs a Warrior" data-summary="Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
@@ -249,17 +271,17 @@
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/agentic-ai-weapon-that-no-longer-needs.html" target="_blank" rel="noopener">Agentic AI: The Weapon That No Longer Needs a Warrior</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 6:30 AM</time>
+            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 11:30 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-5">
+            <summary class="summary-toggle" aria-controls="summary-full-6">
               <span class="summary-preview-text">Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-5">rifle placed a man&#39;s death a quarter mile...</p>
+            <p class="news-summary summary-full" id="summary-full-6">rifle placed a man&#39;s death a quarter mile...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT" data-summary="Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
@@ -276,19 +298,19 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/malicious-npm-packages-pose-as-postcss.html" target="_blank" rel="noopener">Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 3:54 AM</time>
+            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 8:54 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-6">
+            <summary class="summary-toggle" aria-controls="summary-full-7">
               <span class="summary-preview-text">Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
 
 The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-6">identified packages, is below -
+            <p class="news-summary summary-full" id="summary-full-7">identified packages, is below -
 
 
   aes-...</p>
@@ -303,16 +325,16 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/whatsapp-vbscript-campaign-uses-fake.html" target="_blank" rel="noopener">WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 12:38 AM</time>
+            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 5:38 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-7">
+            <summary class="summary-toggle" aria-controls="summary-full-8">
               <span class="summary-preview-text">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-7">Remote Monitoring and Management (RMM) softwar...</p>
+            <p class="news-summary summary-full" id="summary-full-8">Remote Monitoring and Management (RMM) softwar...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws" data-summary="OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="OpenAI" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
@@ -324,17 +346,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/openai-expands-daybreak-with-gpt-55.html" target="_blank" rel="noopener">OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T03:56:58.000Z">June 22, 2026 at 10:56 PM</time>
+            <time datetime="2026-06-23T03:56:58.000Z">June 23, 2026 at 3:56 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">OpenAI</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-8">
+            <summary class="summary-toggle" aria-controls="summary-full-9">
               <span class="summary-preview-text">OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-8">intelligence (AI) company announced last mont...</p>
+            <p class="news-summary summary-full" id="summary-full-9">intelligence (AI) company announced last mont...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="WhatsApp phishing attack uses fake business docs to hack PCs" data-summary="An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]..." data-severity="Elevated" data-tags="Identity,Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
@@ -346,17 +368,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/whatsapp-phishing-attack-uses-fake-business-docs-to-hack-pcs/" target="_blank" rel="noopener">WhatsApp phishing attack uses fake business docs to hack PCs</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 5:42 PM</time>
+            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 10:42 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-9">
+            <summary class="summary-toggle" aria-controls="summary-full-10">
               <span class="summary-preview-text">An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-9">access. [...]...</p>
+            <p class="news-summary summary-full" id="summary-full-10">access. [...]...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="JaredFromSubway MEV bot hacked in $15 million crypto theft" data-summary="The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
@@ -368,16 +390,16 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/jaredfromsubway-mev-bot-hacked-in-15-million-crypto-theft/" target="_blank" rel="noopener">JaredFromSubway MEV bot hacked in $15 million crypto theft</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 4:52 PM</time>
+            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 9:52 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-10">
+            <summary class="summary-toggle" aria-controls="summary-full-11">
               <span class="summary-preview-text">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-10">creating fake cryptocurrency trading oppor...</p>
+            <p class="news-summary summary-full" id="summary-full-11">creating fake cryptocurrency trading oppor...</p>
           </details>
         </article>
         <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories" data-summary="Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data...." data-severity="Elevated" data-tags="Vulnerability,Exploitation,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage">
@@ -389,17 +411,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/application-security/difytap-bugs-wiretap-ai-chat-histories" target="_blank" rel="noopener">DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 4:14 PM</time>
+            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 9:14 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-11">
+            <summary class="summary-toggle" aria-controls="summary-full-12">
               <span class="summary-preview-text">Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-11">data....</p>
+            <p class="news-summary summary-full" id="summary-full-12">data....</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FFmpeg fixes PixelSmash flaw in widely used video decoder" data-summary="A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage">
@@ -411,17 +433,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/ffmpeg-fixes-pixelsmash-flaw-in-widely-used-video-decoder/" target="_blank" rel="noopener">FFmpeg fixes PixelSmash flaw in widely used video decoder</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 4:05 PM</time>
+            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 9:05 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-12">
+            <summary class="summary-toggle" aria-controls="summary-full-13">
               <span class="summary-preview-text">A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-12">trigger a denial-of-service  condition in appl...</p>
+            <p class="news-summary summary-full" id="summary-full-13">trigger a denial-of-service  condition in appl...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FortiBleed campaign used custom FortiGate sniffer to steal credentials" data-summary="Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="Fortinet" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch,SentryInsight: vendor watch">
@@ -433,17 +455,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/fortibleed-campaign-used-custom-fortigate-sniffer-to-steal-credentials/" target="_blank" rel="noopener">FortiBleed campaign used custom FortiGate sniffer to steal credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 3:01 PM</time>
+            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 8:01 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-13">
+            <summary class="summary-toggle" aria-controls="summary-full-14">
               <span class="summary-preview-text">Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-13">from compromised firewalls and steal credent...</p>
+            <p class="news-summary summary-full" id="summary-full-14">from compromised firewalls and steal credent...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack" data-summary="Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
@@ -457,17 +479,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/shapedplugin-wordpress-pro-plugins.html" target="_blank" rel="noopener">ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 1:00 PM</time>
+            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 6:00 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-14">
+            <summary class="summary-toggle" aria-controls="summary-full-15">
               <span class="summary-preview-text">Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-14">channels and push backdoor code.
+            <p class="news-summary summary-full" id="summary-full-15">channels and push backdoor code.
 
 &quot;Attack...</p>
           </details>
@@ -481,17 +503,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/microsoft/microsoft-says-windows-11-26h2-is-coming-soon-details-upgrade-process/" target="_blank" rel="noopener">Microsoft says Windows 11 26H2 is coming soon, details upgrade process</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 12:41 PM</time>
+            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 5:41 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-15">
+            <summary class="summary-toggle" aria-controls="summary-full-16">
               <span class="summary-preview-text">Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-15">using a small enablement package. [...]...</p>
+            <p class="news-summary summary-full" id="summary-full-16">using a small enablement package. [...]...</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft fixes AutoGen Studio flaw that enabled code execution" data-summary="A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="Microsoft" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
@@ -503,17 +525,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/microsoft-fixes-autogen-studio-flaw-that-enabled-code-execution/" target="_blank" rel="noopener">Microsoft fixes AutoGen Studio flaw that enabled code execution</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 12:28 PM</time>
+            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 5:28 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-16">
+            <summary class="summary-toggle" aria-controls="summary-full-17">
               <span class="summary-preview-text">A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-16">arbitrary commands on its host system sim...</p>
+            <p class="news-summary summary-full" id="summary-full-17">arbitrary commands on its host system sim...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests" data-summary="A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
@@ -525,17 +547,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/29-year-old-squid-proxy-bug-squidbleed.html" target="_blank" rel="noopener">29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 11:29 AM</time>
+            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 4:29 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-17">
+            <summary class="summary-toggle" aria-controls="summary-full-18">
               <span class="summary-preview-text">A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-17">already allowed to send traffic through the sa...</p>
+            <p class="news-summary summary-full" id="summary-full-18">already allowed to send traffic through the sa...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants" data-summary="Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
@@ -547,17 +569,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/researchers-detail-difytap-flaws-in.html" target="_blank" rel="noopener">Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 11:13 AM</time>
+            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 4:13 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-18">
+            <summary class="summary-toggle" aria-controls="summary-full-19">
               <span class="summary-preview-text">Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars,</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-18">that could allow attackers to stealthily...</p>
+            <p class="news-summary summary-full" id="summary-full-19">that could allow attackers to stealthily...</p>
           </details>
         </article>
         <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign" data-summary="Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker...." data-severity="Monitor" data-tags="" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
@@ -569,17 +591,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/crypto-heist-fake-reputation-boosting-campaign" target="_blank" rel="noopener">Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 11:10 AM</time>
+            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 4:10 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-19">
+            <summary class="summary-toggle" aria-controls="summary-full-20">
               <span class="summary-preview-text">Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-19">hijacker....</p>
+            <p class="news-summary summary-full" id="summary-full-20">hijacker....</p>
           </details>
         </article>
         <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="He Thought He Was Secure; His Phone Number Got Stolen Anyway" data-summary="Threat actors can easily steal one-time passwords sent by text when they conduct a SIM swap attack. This can lead to account takeovers, so users must layer up their security measures...." data-severity="Elevated" data-tags="Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
@@ -591,16 +613,16 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyber-risk/how-a-sim-swap-attack-led-to-a-near-account-takeover" target="_blank" rel="noopener">He Thought He Was Secure; His Phone Number Got Stolen Anyway</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:12:11.000Z">June 22, 2026 at 9:12 AM</time>
+            <time datetime="2026-06-22T14:12:11.000Z">June 22, 2026 at 2:12 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Identity</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-20">
+            <summary class="summary-toggle" aria-controls="summary-full-21">
               <span class="summary-preview-text">Threat actors can easily steal one-time passwords sent by text when they conduct a SIM swap attack. This can lead to account takeovers, so users must layer up</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-20">their security measures....</p>
+            <p class="news-summary summary-full" id="summary-full-21">their security measures....</p>
           </details>
         </article>
         <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="A Glimpse into the “Search Your Target” Market for Stolen Credentials" data-summary="Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
@@ -612,16 +634,16 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/a-glimpse-into-the-search-your-target-market-for-stolen-credentials/" target="_blank" rel="noopener">A Glimpse into the “Search Your Target” Market for Stolen Credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 9:05 AM</time>
+            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 2:05 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-21">
+            <summary class="summary-toggle" aria-controls="summary-full-22">
               <span class="summary-preview-text">Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-21">searches stolen credential databases for spe...</p>
+            <p class="news-summary summary-full" id="summary-full-22">searches stolen credential databases for spe...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer" data-summary="Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
@@ -635,16 +657,16 @@ According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Mal
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/new-oxloader-loader-uses-malicious.html" target="_blank" rel="noopener">New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 8:20 AM</time>
+            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 1:20 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-22">
+            <summary class="summary-toggle" aria-controls="summary-full-23">
               <span class="summary-preview-text">Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-22">OXLOADER.
+            <p class="news-summary summary-full" id="summary-full-23">OXLOADER.
 
 According to Elastic Security Labs, ...</p>
           </details>
@@ -660,16 +682,16 @@ On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/google-sets-sept-30-deadline-for.html" target="_blank" rel="noopener">Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 7:45 AM</time>
+            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 12:45 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-23">
+            <summary class="summary-toggle" aria-controls="summary-full-24">
               <span class="summary-preview-text">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-23">stores are in from the start.
+            <p class="news-summary summary-full" id="summary-full-24">stores are in from the start.
 
 On that date...</p>
           </details>
@@ -683,16 +705,16 @@ On that date...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/stop-your-legacy-infrastructure-from.html" target="_blank" rel="noopener">Stop Your Legacy Infrastructure from Hijacking Your AI Agents</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 6:58 AM</time>
+            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 11:58 AM</time>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-24">
+            <summary class="summary-toggle" aria-controls="summary-full-25">
               <span class="summary-preview-text">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-24">attackers are circumventing AI security progra...</p>
+            <p class="news-summary summary-full" id="summary-full-25">attackers are circumventing AI security progra...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More" data-summary="It’s Monday again.
@@ -706,18 +728,18 @@ This week’s threat list looks painfully familiar: abused integrations, fake to
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/weekly-recap-browser-bugs-edr-killers.html" target="_blank" rel="noopener">⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 5:55 AM</time>
+            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 10:55 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Ransomware</span><span class="chip">Vulnerability</span><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-25">
+            <summary class="summary-toggle" aria-controls="summary-full-26">
               <span class="summary-preview-text">It’s Monday again.
 
 This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-25">security tools, and mobile malware asking...</p>
+            <p class="news-summary summary-full" id="summary-full-26">security tools, and mobile malware asking...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices" data-summary="Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
@@ -731,16 +753,16 @@ The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" 
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/canadas-spy-agency-used-first-of-its.html" target="_blank" rel="noopener">Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 4:11 AM</time>
+            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 9:11 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-26">
+            <summary class="summary-toggle" aria-controls="summary-full-27">
               <span class="summary-preview-text">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-26">foreign-run botnets.
+            <p class="news-summary summary-full" id="summary-full-27">foreign-run botnets.
 
 The Federal Court released a ...</p>
           </details>
@@ -754,16 +776,16 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/arystinger-malware-infects-4300-legacy.html" target="_blank" rel="noopener">AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 1:57 AM</time>
+            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 6:57 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-27">
+            <summary class="summary-toggle" aria-controls="summary-full-28">
               <span class="summary-preview-text">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-27">in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
+            <p class="news-summary summary-full" id="summary-full-28">in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
           </details>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific" data-summary="A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne..." data-severity="Critical" data-tags="Ransomware,Identity,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
@@ -775,37 +797,16 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/interpol-warns-phishing-ransomware-and.html" target="_blank" rel="noopener">INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 1:06 AM</time>
+            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 6:06 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span><span class="chip">Identity</span><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-28">
+            <summary class="summary-toggle" aria-controls="summary-full-29">
               <span class="summary-preview-text">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet</span><span class="summary-ellipsis" aria-hidden="true">...</span>
               <span class="summary-action">Show full summary</span>
             </summary>
-            <p class="news-summary summary-full" id="summary-full-28">penetration, new technologies, organized criminal ne...</p>
-          </details>
-        </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="AryStinger botnet infected thousands of D-Link routers worldwide" data-summary="A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
-          <div class="chips">
-            <span class="severity severity-elevated">Elevated</span>
-            <span class="chip"><span class="dot"></span>Bleeping Computer</span>
-            <span class="chip">bleepingcomputer.com</span>
-            <span class="chip">Industry media</span>
-          </div>
-          <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/arystinger-botnet-infected-thousands-of-d-link-routers-worldwide/" target="_blank" rel="noopener">AryStinger botnet infected thousands of D-Link routers worldwide</a></h2>
-          <div class="news-meta">
-            <time datetime="2026-06-21T14:14:22.000Z">June 21, 2026 at 9:14 AM</time>
-          </div>
-          <div class="facet-row"><span class="chip">Malware</span></div>
-          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
-          <details class="summary-disclosure">
-            <summary class="summary-toggle" aria-controls="summary-full-29">
-              <span class="summary-preview-text">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic.</span><span class="summary-ellipsis" aria-hidden="true">...</span>
-              <span class="summary-action">Show full summary</span>
-            </summary>
-            <p class="news-summary summary-full" id="summary-full-29">[...]...</p>
+            <p class="news-summary summary-full" id="summary-full-29">penetration, new technologies, organized criminal ne...</p>
           </details>
         </article>
     </div>
@@ -862,7 +863,7 @@ The Federal Court released a ...</p>
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T14:30:06.072Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T14:32:08.790Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));

--- a/index.html
+++ b/index.html
@@ -63,6 +63,8 @@
     [data-theme="dark"] .severity-elevated { background: rgba(245,158,11,0.18); color: #fde68a; }
     [data-theme="dark"] .severity-monitor { background: rgba(14,165,233,0.18); color: #bae6fd; }
     .facet-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+    .handoff-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+    .handoff-cue { border: 1px solid var(--card-border); border-radius: 6px; color: var(--muted); display: inline-flex; font-size: 12px; padding: 3px 8px; }
     .news-title { font-size: 1.06rem; margin: 6px 0 8px; }
     .news-title a { color: var(--fg); text-decoration: none; }
     .news-title a:hover { text-decoration: underline; }
@@ -130,12 +132,12 @@
         <option value="Fortinet">Fortinet</option><option value="GitHub">GitHub</option><option value="Google">Google</option><option value="Microsoft">Microsoft</option><option value="OpenAI">OpenAI</option>
       </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T14:15:42.542Z">6/23/2026, 2:15:42 PM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T14:30:06.072Z">6/23/2026, 9:30:06 AM</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
       
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="The Exploit Doesn&#39;t Exist. You Can Still Prove It Works Against You" data-summary="Attackers can now weaponize newly disclosed vulnerabilities far faster than most organizations can patch them. Picus Security explains how security teams can validate exploitability before a public ex..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="The Exploit Doesn&#39;t Exist. You Can Still Prove It Works Against You" data-summary="Attackers can now weaponize newly disclosed vulnerabilities far faster than most organizations can patch them. Picus Security explains how security teams can validate exploitability before a public ex..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -144,10 +146,11 @@
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/the-exploit-doesnt-exist-you-can-still-prove-it-works-against-you/" target="_blank" rel="noopener">The Exploit Doesn&#39;t Exist. You Can Still Prove It Works Against You</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T14:01:11.000Z">June 23, 2026 at 2:01 PM</time>
+            <time datetime="2026-06-23T14:01:11.000Z">June 23, 2026 at 9:01 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-0">
               <span class="summary-preview-text">Attackers can now weaponize newly disclosed vulnerabilities far faster than most organizations can patch them. Picus Security explains how security teams can</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -156,7 +159,7 @@
             <p class="news-summary summary-full" id="summary-full-0">validate exploitability before a public ex...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="LastPass confirms data breach in Klue supply chain attack" data-summary="LastPass announced that hackers accessed customer data from its Salesforce environment after stealing the company&#39;s OAuth tokens in the Klue supply chain attack earlier this month. [...]..." data-severity="Critical" data-tags="Data Breach,Identity,Supply Chain" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="LastPass confirms data breach in Klue supply chain attack" data-summary="LastPass announced that hackers accessed customer data from its Salesforce environment after stealing the company&#39;s OAuth tokens in the Klue supply chain attack earlier this month. [...]..." data-severity="Critical" data-tags="Data Breach,Identity,Supply Chain" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -165,10 +168,11 @@
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/lastpass-confirms-data-breach-in-klue-supply-chain-attack/" target="_blank" rel="noopener">LastPass confirms data breach in Klue supply chain attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T13:58:25.000Z">June 23, 2026 at 1:58 PM</time>
+            <time datetime="2026-06-23T13:58:25.000Z">June 23, 2026 at 8:58 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span><span class="chip">Supply Chain</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-1">
               <span class="summary-preview-text">LastPass announced that hackers accessed customer data from its Salesforce environment after stealing the company&#39;s OAuth tokens in the Klue supply chain</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -177,7 +181,7 @@
             <p class="news-summary summary-full" id="summary-full-1">attack earlier this month. [...]...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="SocGholish Takedown Highlights Malicious TDS Threats" data-summary="SocGholish uses traffic distribution systems (TDSs) to provide initial access into victims&#39; networks for cybercrime groups such as the notorious Evil Corp...." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="SocGholish Takedown Highlights Malicious TDS Threats" data-summary="SocGholish uses traffic distribution systems (TDSs) to provide initial access into victims&#39; networks for cybercrime groups such as the notorious Evil Corp...." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
@@ -186,12 +190,13 @@
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyber-risk/socgholish-takedown-malicious-tds-threats" target="_blank" rel="noopener">SocGholish Takedown Highlights Malicious TDS Threats</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T13:51:33.000Z">June 23, 2026 at 1:51 PM</time>
+            <time datetime="2026-06-23T13:51:33.000Z">June 23, 2026 at 8:51 AM</time>
             <span class="badge-new">NEW</span>
           </div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <p class="news-summary">SocGholish uses traffic distribution systems (TDSs) to provide initial access into victims&#39; networks for cybercrime groups such as the notorious Evil Corp....</p>
         </article>
-        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist" data-summary="The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global campaign...." data-severity="Elevated" data-tags="Identity" data-vendors="Fortinet" data-source-signal="Industry media">
+        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist" data-summary="The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global campaign...." data-severity="Elevated" data-tags="Identity" data-vendors="Fortinet" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch,SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
@@ -200,10 +205,11 @@
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/fortibleed-attackers-firewalls-credentials-stealers" target="_blank" rel="noopener">FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 12:34 PM</time>
+            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 7:34 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Identity</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-3">
               <span class="summary-preview-text">The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -212,7 +218,7 @@
             <p class="news-summary summary-full" id="summary-full-3">campaign....</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Webinar: Why email security teams are drowning in alerts" data-summary="Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl..." data-severity="Elevated" data-tags="Identity,AI Security" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Webinar: Why email security teams are drowning in alerts" data-summary="Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl..." data-severity="Elevated" data-tags="Identity,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -221,10 +227,11 @@
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/webinar-why-email-security-teams-are-drowning-in-alerts/" target="_blank" rel="noopener">Webinar: Why email security teams are drowning in alerts</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 12:12 PM</time>
+            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 7:12 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">AI Security</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-4">
               <span class="summary-preview-text">Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -233,7 +240,7 @@
             <p class="news-summary summary-full" id="summary-full-4">help automate detection and response workfl...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Agentic AI: The Weapon That No Longer Needs a Warrior" data-summary="Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Agentic AI: The Weapon That No Longer Needs a Warrior" data-summary="Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -242,10 +249,11 @@
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/agentic-ai-weapon-that-no-longer-needs.html" target="_blank" rel="noopener">Agentic AI: The Weapon That No Longer Needs a Warrior</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 11:30 AM</time>
+            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 6:30 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-5">
               <span class="summary-preview-text">Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -259,7 +267,7 @@
 The list of identified packages, is below -
 
 
-  aes-..." data-severity="Elevated" data-tags="Malware,Supply Chain" data-vendors="Microsoft" data-source-signal="Industry media">
+  aes-..." data-severity="Elevated" data-tags="Malware,Supply Chain" data-vendors="Microsoft" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -268,10 +276,11 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/malicious-npm-packages-pose-as-postcss.html" target="_blank" rel="noopener">Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 8:54 AM</time>
+            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 3:54 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-6">
               <span class="summary-preview-text">Cybersecurity researchers have discovered a set of malicious npm packages that are designed to deliver a Windows-based remote access trojan (RAT).
@@ -285,7 +294,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
   aes-...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool" data-summary="Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool" data-summary="Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -294,9 +303,10 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/whatsapp-vbscript-campaign-uses-fake.html" target="_blank" rel="noopener">WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 5:38 AM</time>
+            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 12:38 AM</time>
             <span class="badge-new">NEW</span>
           </div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-7">
               <span class="summary-preview-text">Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -305,7 +315,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-7">Remote Monitoring and Management (RMM) softwar...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws" data-summary="OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="OpenAI" data-source-signal="Industry media">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws" data-summary="OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="OpenAI" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -314,10 +324,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/openai-expands-daybreak-with-gpt-55.html" target="_blank" rel="noopener">OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T03:56:58.000Z">June 23, 2026 at 3:56 AM</time>
+            <time datetime="2026-06-23T03:56:58.000Z">June 22, 2026 at 10:56 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">OpenAI</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-8">
               <span class="summary-preview-text">OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -326,7 +337,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-8">intelligence (AI) company announced last mont...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="WhatsApp phishing attack uses fake business docs to hack PCs" data-summary="An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]..." data-severity="Elevated" data-tags="Identity,Malware" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="WhatsApp phishing attack uses fake business docs to hack PCs" data-summary="An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]..." data-severity="Elevated" data-tags="Identity,Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -335,10 +346,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/whatsapp-phishing-attack-uses-fake-business-docs-to-hack-pcs/" target="_blank" rel="noopener">WhatsApp phishing attack uses fake business docs to hack PCs</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 10:42 PM</time>
+            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 5:42 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">Malware</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-9">
               <span class="summary-preview-text">An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -347,7 +359,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-9">access. [...]...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="JaredFromSubway MEV bot hacked in $15 million crypto theft" data-summary="The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="JaredFromSubway MEV bot hacked in $15 million crypto theft" data-summary="The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -356,9 +368,10 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/jaredfromsubway-mev-bot-hacked-in-15-million-crypto-theft/" target="_blank" rel="noopener">JaredFromSubway MEV bot hacked in $15 million crypto theft</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 9:52 PM</time>
+            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 4:52 PM</time>
             <span class="badge-new">NEW</span>
           </div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-10">
               <span class="summary-preview-text">The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -367,7 +380,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-10">creating fake cryptocurrency trading oppor...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories" data-summary="Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data...." data-severity="Elevated" data-tags="Vulnerability,Exploitation,AI Security" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories" data-summary="Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data...." data-severity="Elevated" data-tags="Vulnerability,Exploitation,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
@@ -376,10 +389,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/application-security/difytap-bugs-wiretap-ai-chat-histories" target="_blank" rel="noopener">DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 9:14 PM</time>
+            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 4:14 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span><span class="chip">AI Security</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-11">
               <span class="summary-preview-text">Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -388,7 +402,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-11">data....</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FFmpeg fixes PixelSmash flaw in widely used video decoder" data-summary="A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FFmpeg fixes PixelSmash flaw in widely used video decoder" data-summary="A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -397,10 +411,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/ffmpeg-fixes-pixelsmash-flaw-in-widely-used-video-decoder/" target="_blank" rel="noopener">FFmpeg fixes PixelSmash flaw in widely used video decoder</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 9:05 PM</time>
+            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 4:05 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-12">
               <span class="summary-preview-text">A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -409,7 +424,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-12">trigger a denial-of-service  condition in appl...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FortiBleed campaign used custom FortiGate sniffer to steal credentials" data-summary="Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="Fortinet" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FortiBleed campaign used custom FortiGate sniffer to steal credentials" data-summary="Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="Fortinet" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch,SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -418,10 +433,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/fortibleed-campaign-used-custom-fortigate-sniffer-to-steal-credentials/" target="_blank" rel="noopener">FortiBleed campaign used custom FortiGate sniffer to steal credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 8:01 PM</time>
+            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 3:01 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-13">
               <span class="summary-preview-text">Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -432,7 +448,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack" data-summary="Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
 
-&quot;Attack..." data-severity="Elevated" data-tags="Malware,Supply Chain" data-vendors="" data-source-signal="Industry media">
+&quot;Attack..." data-severity="Elevated" data-tags="Malware,Supply Chain" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -441,10 +457,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/shapedplugin-wordpress-pro-plugins.html" target="_blank" rel="noopener">ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 6:00 PM</time>
+            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 1:00 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-14">
               <span class="summary-preview-text">Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -455,7 +472,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
 &quot;Attack...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft says Windows 11 26H2 is coming soon, details upgrade process" data-summary="Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]..." data-severity="Monitor" data-tags="" data-vendors="Microsoft" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft says Windows 11 26H2 is coming soon, details upgrade process" data-summary="Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]..." data-severity="Monitor" data-tags="" data-vendors="Microsoft" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -464,10 +481,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/microsoft/microsoft-says-windows-11-26h2-is-coming-soon-details-upgrade-process/" target="_blank" rel="noopener">Microsoft says Windows 11 26H2 is coming soon, details upgrade process</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 5:41 PM</time>
+            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 12:41 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-15">
               <span class="summary-preview-text">Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -476,7 +494,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-15">using a small enablement package. [...]...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft fixes AutoGen Studio flaw that enabled code execution" data-summary="A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="Microsoft" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft fixes AutoGen Studio flaw that enabled code execution" data-summary="A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="Microsoft" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -485,10 +503,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/microsoft-fixes-autogen-studio-flaw-that-enabled-code-execution/" target="_blank" rel="noopener">Microsoft fixes AutoGen Studio flaw that enabled code execution</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 5:28 PM</time>
+            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 12:28 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-16">
               <span class="summary-preview-text">A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -497,7 +516,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-16">arbitrary commands on its host system sim...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests" data-summary="A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests" data-summary="A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -506,10 +525,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/29-year-old-squid-proxy-bug-squidbleed.html" target="_blank" rel="noopener">29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 4:29 PM</time>
+            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 11:29 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-17">
               <span class="summary-preview-text">A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -518,7 +538,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-17">already allowed to send traffic through the sa...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants" data-summary="Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="GitHub" data-source-signal="Industry media">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants" data-summary="Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -527,10 +547,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/researchers-detail-difytap-flaws-in.html" target="_blank" rel="noopener">Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 4:13 PM</time>
+            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 11:13 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-18">
               <span class="summary-preview-text">Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars,</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -539,7 +560,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-18">that could allow attackers to stealthily...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign" data-summary="Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker...." data-severity="Monitor" data-tags="" data-vendors="GitHub" data-source-signal="Industry media">
+        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign" data-summary="Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker...." data-severity="Monitor" data-tags="" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
@@ -548,10 +569,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/crypto-heist-fake-reputation-boosting-campaign" target="_blank" rel="noopener">Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 4:10 PM</time>
+            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 11:10 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-19">
               <span class="summary-preview-text">Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -560,7 +582,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-19">hijacker....</p>
           </details>
         </article>
-        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="He Thought He Was Secure; His Phone Number Got Stolen Anyway" data-summary="Threat actors can easily steal one-time passwords sent by text when they conduct a SIM swap attack. This can lead to account takeovers, so users must layer up their security measures...." data-severity="Elevated" data-tags="Identity" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="He Thought He Was Secure; His Phone Number Got Stolen Anyway" data-summary="Threat actors can easily steal one-time passwords sent by text when they conduct a SIM swap attack. This can lead to account takeovers, so users must layer up their security measures...." data-severity="Elevated" data-tags="Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
@@ -569,9 +591,10 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyber-risk/how-a-sim-swap-attack-led-to-a-near-account-takeover" target="_blank" rel="noopener">He Thought He Was Secure; His Phone Number Got Stolen Anyway</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:12:11.000Z">June 22, 2026 at 2:12 PM</time>
+            <time datetime="2026-06-22T14:12:11.000Z">June 22, 2026 at 9:12 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Identity</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-20">
               <span class="summary-preview-text">Threat actors can easily steal one-time passwords sent by text when they conduct a SIM swap attack. This can lead to account takeovers, so users must layer up</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -580,7 +603,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-20">their security measures....</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="A Glimpse into the “Search Your Target” Market for Stolen Credentials" data-summary="Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="A Glimpse into the “Search Your Target” Market for Stolen Credentials" data-summary="Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -589,9 +612,10 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/a-glimpse-into-the-search-your-target-market-for-stolen-credentials/" target="_blank" rel="noopener">A Glimpse into the “Search Your Target” Market for Stolen Credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 2:05 PM</time>
+            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 9:05 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-21">
               <span class="summary-preview-text">Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -602,7 +626,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer" data-summary="Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
 
-According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Malware" data-vendors="Google" data-source-signal="Industry media">
+According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Malware" data-vendors="Google" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -611,9 +635,10 @@ According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Mal
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/new-oxloader-loader-uses-malicious.html" target="_blank" rel="noopener">New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 1:20 PM</time>
+            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 8:20 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Malware</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-22">
               <span class="summary-preview-text">Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -626,7 +651,7 @@ According to Elastic Security Labs, ...</p>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries" data-summary="Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app stores are in from the start.
 
-On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data-source-signal="Industry media">
+On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -635,9 +660,10 @@ On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/google-sets-sept-30-deadline-for.html" target="_blank" rel="noopener">Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 12:45 PM</time>
+            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 7:45 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-23">
               <span class="summary-preview-text">Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -648,7 +674,7 @@ On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data
 On that date...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Stop Your Legacy Infrastructure from Hijacking Your AI Agents" data-summary="Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Stop Your Legacy Infrastructure from Hijacking Your AI Agents" data-summary="Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -657,9 +683,10 @@ On that date...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/stop-your-legacy-infrastructure-from.html" target="_blank" rel="noopener">Stop Your Legacy Infrastructure from Hijacking Your AI Agents</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 11:58 AM</time>
+            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 6:58 AM</time>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-24">
               <span class="summary-preview-text">Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -670,7 +697,7 @@ On that date...</p>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More" data-summary="It’s Monday again.
 
-This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down security tools, and mobile malware asking..." data-severity="Critical" data-tags="Ransomware,Vulnerability,Malware" data-vendors="Google" data-source-signal="Industry media">
+This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down security tools, and mobile malware asking..." data-severity="Critical" data-tags="Ransomware,Vulnerability,Malware" data-vendors="Google" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch,SentryInsight: vuln triage,SentryInsight: vendor watch">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -679,9 +706,10 @@ This week’s threat list looks painfully familiar: abused integrations, fake to
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/weekly-recap-browser-bugs-edr-killers.html" target="_blank" rel="noopener">⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 10:55 AM</time>
+            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 5:55 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Ransomware</span><span class="chip">Vulnerability</span><span class="chip">Malware</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-25">
               <span class="summary-preview-text">It’s Monday again.
@@ -694,7 +722,7 @@ This week’s threat list looks painfully familiar: abused integrations, fake to
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices" data-summary="Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
 
-The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media">
+The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -703,9 +731,10 @@ The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" 
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/canadas-spy-agency-used-first-of-its.html" target="_blank" rel="noopener">Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 9:11 AM</time>
+            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 4:11 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-26">
               <span class="summary-preview-text">Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -716,7 +745,7 @@ The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" 
 The Federal Court released a ...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network" data-summary="A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network" data-summary="A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -725,9 +754,10 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/arystinger-malware-infects-4300-legacy.html" target="_blank" rel="noopener">AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 6:57 AM</time>
+            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 1:57 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-27">
               <span class="summary-preview-text">A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -736,7 +766,7 @@ The Federal Court released a ...</p>
             <p class="news-summary summary-full" id="summary-full-27">in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific" data-summary="A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne..." data-severity="Critical" data-tags="Ransomware,Identity,AI Security" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific" data-summary="A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne..." data-severity="Critical" data-tags="Ransomware,Identity,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
@@ -745,9 +775,10 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/interpol-warns-phishing-ransomware-and.html" target="_blank" rel="noopener">INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 6:06 AM</time>
+            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 1:06 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span><span class="chip">Identity</span><span class="chip">AI Security</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-28">
               <span class="summary-preview-text">A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -756,7 +787,7 @@ The Federal Court released a ...</p>
             <p class="news-summary summary-full" id="summary-full-28">penetration, new technologies, organized criminal ne...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="AryStinger botnet infected thousands of D-Link routers worldwide" data-summary="A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="AryStinger botnet infected thousands of D-Link routers worldwide" data-summary="A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
@@ -765,9 +796,10 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/arystinger-botnet-infected-thousands-of-d-link-routers-worldwide/" target="_blank" rel="noopener">AryStinger botnet infected thousands of D-Link routers worldwide</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-21T14:14:22.000Z">June 21, 2026 at 2:14 PM</time>
+            <time datetime="2026-06-21T14:14:22.000Z">June 21, 2026 at 9:14 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
+          <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <details class="summary-disclosure">
             <summary class="summary-toggle" aria-controls="summary-full-29">
               <span class="summary-preview-text">A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic.</span><span class="summary-ellipsis" aria-hidden="true">...</span>
@@ -830,7 +862,7 @@ The Federal Court released a ...</p>
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T14:15:42.542Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T14:30:06.072Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));

--- a/news-data.json
+++ b/news-data.json
@@ -1,5 +1,12 @@
 [
   {
+    "title": "GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns",
+    "link": "https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html",
+    "date": "2026-06-23T14:22:03.000Z",
+    "source": "The Hacker News",
+    "summary": "GitHub is moving to strengthen software supply chain security by updating \"actions/checkout\" to block pwn request attacks that exploit the risky use of the \"pull_request_target workflow\" trigger to ru..."
+  },
+  {
     "title": "The Exploit Doesn't Exist. You Can Still Prove It Works Against You",
     "link": "https://www.bleepingcomputer.com/news/security/the-exploit-doesnt-exist-you-can-still-prove-it-works-against-you/",
     "date": "2026-06-23T14:01:11.000Z",
@@ -201,12 +208,5 @@
     "date": "2026-06-22T06:06:53.000Z",
     "source": "The Hacker News",
     "summary": "A new report from INTERPOL has revealed a \"dramatic increase\" in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne..."
-  },
-  {
-    "title": "AryStinger botnet infected thousands of D-Link routers worldwide",
-    "link": "https://www.bleepingcomputer.com/news/security/arystinger-botnet-infected-thousands-of-d-link-routers-worldwide/",
-    "date": "2026-06-21T14:14:22.000Z",
-    "source": "Bleeping Computer",
-    "summary": "A previously undocumented malware botnet named AryStinger has compromised more than 4,000 outdated routers to turn them into proxies for malicious traffic. [...]..."
   }
 ]

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -59,6 +59,35 @@ const SOURCE_SIGNAL_RULES = [
   { label: 'Industry media', pattern: /\b(securityweek|bleepingcomputer|the hacker news|dark reading|krebsonsecurity|threatpost|wired|therecord)\b/i },
 ];
 
+const HANDOFF_CUE_RULES = [
+  {
+    label: 'SentryInsight: incident watch',
+    matches: ({ facets, text }) => (
+      facets.severity === 'Critical'
+      || facets.tags.some((tag) => ['Ransomware', 'Data Breach', 'Identity'].includes(tag))
+      || /\b(incident response|intrusion|compromise|stolen credentials?|credential theft)\b/i.test(text)
+    ),
+  },
+  {
+    label: 'SentryInsight: vuln triage',
+    matches: ({ facets, text }) => (
+      facets.tags.some((tag) => ['Vulnerability', 'Exploitation'].includes(tag))
+      || /\bcve-\d{4}-\d+\b/i.test(text)
+    ),
+  },
+  {
+    label: 'SentryInsight: vendor watch',
+    matches: ({ facets }) => facets.vendors.length > 0 || facets.sourceSignal === 'Vendor advisory',
+  },
+  {
+    label: 'GRCInsight: governance watch',
+    matches: ({ facets, text }) => (
+      facets.tags.includes('Compliance')
+      || /\b(grc|governance|compliance|regulator|regulatory|privacy|gdpr|sec\b|filings?|audit)\b/i.test(text)
+    ),
+  },
+];
+
 function matchesRule(text, rule) {
   return rule.pattern.test(text);
 }
@@ -92,6 +121,18 @@ function deriveArticleFacets(article) {
     vendors,
     sourceSignal,
   };
+}
+
+function deriveHandoffCues(article) {
+  const safeLink = safeArticleLink(article.link);
+  const host = safeLink === '#' ? '' : new URL(safeLink).hostname.replace(/^www\./, '');
+  const text = `${article.title || ''} ${article.summary || ''} ${article.source || ''} ${host}`;
+  const facets = deriveArticleFacets(article);
+  const cues = HANDOFF_CUE_RULES
+    .filter((rule) => rule.matches({ article, facets, text }))
+    .map((rule) => rule.label);
+
+  return cues.length > 0 ? cues : ['SentryInsight: monitor'];
 }
 
 function collectFacetFilterOptions(newsItems) {
@@ -180,6 +221,7 @@ function renderSummary(summary, index) {
 function renderArticleCard(article, index = 0) {
   const articleLink = safeArticleLink(article.link);
   const facets = deriveArticleFacets(article);
+  const handoffCues = deriveHandoffCues(article);
   const hostname = (() => {
     try {
       return new URL(articleLink).hostname.replace(/^www\./, '');
@@ -205,15 +247,18 @@ function renderArticleCard(article, index = 0) {
   const safeSourceSignalAttr = escapeAttribute(facets.sourceSignal);
   const safeTagsAttr = escapeAttribute(facets.tags.join(','));
   const safeVendorsAttr = escapeAttribute(facets.vendors.join(','));
+  const safeHandoffCuesAttr = escapeAttribute(handoffCues.join(','));
   const vendorChips = facets.vendors.map((vendor) => `<span class="chip">${escapeHtml(vendor)}</span>`).join('');
   const tagChips = facets.tags.map((tag) => `<span class="chip">${escapeHtml(tag)}</span>`).join('');
+  const handoffCueChips = handoffCues.map((cue) => `<span class="handoff-cue">${escapeHtml(cue)}</span>`).join('');
   const hostChip = hostname ? `\n            <span class="chip">${safeHost}</span>` : '';
   const newBadge = isNew ? `\n            <span class="badge-new">NEW</span>` : '';
   const facetRow = (vendorChips || tagChips) ? `\n          <div class="facet-row">${vendorChips}${tagChips}</div>` : '';
+  const handoffRow = `\n          <div class="handoff-row" aria-label="Downstream handoff cues">${handoffCueChips}</div>`;
   const summary = renderSummary(article.summary, index);
 
   return `
-        <article class="news-item" data-source="${safeSourceAttr}" data-host="${safeHostAttr}" data-title="${safeTitleAttr}" data-summary="${safeSummaryAttr}" data-severity="${safeSeverityAttr}" data-tags="${safeTagsAttr}" data-vendors="${safeVendorsAttr}" data-source-signal="${safeSourceSignalAttr}">
+        <article class="news-item" data-source="${safeSourceAttr}" data-host="${safeHostAttr}" data-title="${safeTitleAttr}" data-summary="${safeSummaryAttr}" data-severity="${safeSeverityAttr}" data-tags="${safeTagsAttr}" data-vendors="${safeVendorsAttr}" data-source-signal="${safeSourceSignalAttr}" data-handoff-cues="${safeHandoffCuesAttr}">
           <div class="chips">
             <span class="severity severity-${safeSeverityClass}">${safeSeverity}</span>
             <span class="chip"><span class="dot"></span>${safeSource}</span>${hostChip}
@@ -222,7 +267,7 @@ function renderArticleCard(article, index = 0) {
           <h2 class="news-title"><a href="${safeLink}" target="_blank" rel="noopener">${safeTitle}</a></h2>
           <div class="news-meta">
             <time datetime="${dateIso}">${dateText}</time>${newBadge}
-          </div>${facetRow}
+          </div>${facetRow}${handoffRow}
           ${summary}
         </article>`;
 }
@@ -314,6 +359,8 @@ function generateHTML(newsItems) {
     [data-theme="dark"] .severity-elevated { background: rgba(245,158,11,0.18); color: #fde68a; }
     [data-theme="dark"] .severity-monitor { background: rgba(14,165,233,0.18); color: #bae6fd; }
     .facet-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+    .handoff-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+    .handoff-cue { border: 1px solid var(--card-border); border-radius: 6px; color: var(--muted); display: inline-flex; font-size: 12px; padding: 3px 8px; }
     .news-title { font-size: 1.06rem; margin: 6px 0 8px; }
     .news-title a { color: var(--fg); text-decoration: none; }
     .news-title a:hover { text-decoration: underline; }
@@ -461,6 +508,7 @@ function generateHTML(newsItems) {
 module.exports = {
   collectFacetFilterOptions,
   deriveArticleFacets,
+  deriveHandoffCues,
   escapeHtml,
   formatArticleDate,
   generateHTML,

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -6,7 +6,12 @@ const {
   normalizeArticleDate,
   normalizeFeedDate,
 } = require('../scripts/fetch-news');
-const { collectFacetFilterOptions, deriveArticleFacets, generateHTML } = require('../scripts/render-news-html');
+const {
+  collectFacetFilterOptions,
+  deriveArticleFacets,
+  deriveHandoffCues,
+  generateHTML,
+} = require('../scripts/render-news-html');
 
 test('normalizeFeedDate preserves valid feed dates', () => {
   const date = normalizeFeedDate(
@@ -283,6 +288,23 @@ test('generateHTML renders escaped operator facets on article cards', () => {
   assert.match(html, /<span class="chip">Vulnerability<\/span>/);
 });
 
+test('generateHTML renders escaped downstream handoff cues on article cards', () => {
+  const html = generateHTML([
+    {
+      title: 'Microsoft Exchange zero-day exploited in data breach response',
+      link: 'https://security.example.com/microsoft-exchange-zero-day',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'SecurityWeek',
+      summary: 'SEC filings mention incident response, active exploitation, and stolen credentials.',
+    },
+  ]);
+
+  assert.match(html, /data-handoff-cues="SentryInsight: incident watch,SentryInsight: vuln triage,SentryInsight: vendor watch,GRCInsight: governance watch"/);
+  assert.match(html, /<div class="handoff-row" aria-label="Downstream handoff cues">/);
+  assert.match(html, /<span class="handoff-cue">SentryInsight: incident watch<\/span>/);
+  assert.match(html, /<span class="handoff-cue">GRCInsight: governance watch<\/span>/);
+});
+
 test('collectFacetFilterOptions returns deterministic severity, tag, and vendor options', () => {
   const options = collectFacetFilterOptions([
     {
@@ -304,6 +326,35 @@ test('collectFacetFilterOptions returns deterministic severity, tag, and vendor 
   assert.deepEqual(options.severities, ['Critical', 'Monitor']);
   assert.deepEqual(options.tags, ['AI Security', 'Data Breach', 'Exploitation', 'Ransomware', 'Vulnerability']);
   assert.deepEqual(options.vendors, ['Microsoft']);
+});
+
+test('deriveHandoffCues identifies downstream incident and governance relevance', () => {
+  const cues = deriveHandoffCues({
+    title: 'Microsoft Exchange zero-day exploited in data breach response',
+    link: 'https://security.example.com/microsoft-exchange-zero-day',
+    date: new Date('2026-06-17T18:00:00.000Z'),
+    source: 'SecurityWeek',
+    summary: 'SEC filings mention incident response, active exploitation, and stolen credentials.',
+  });
+
+  assert.deepEqual(cues, [
+    'SentryInsight: incident watch',
+    'SentryInsight: vuln triage',
+    'SentryInsight: vendor watch',
+    'GRCInsight: governance watch',
+  ]);
+});
+
+test('deriveHandoffCues returns a stable monitor cue for low-signal articles', () => {
+  const cues = deriveHandoffCues({
+    title: 'Weekly security podcast roundup',
+    link: 'https://example.com/security-podcast-roundup',
+    date: new Date('2026-06-17T18:00:00.000Z'),
+    source: 'Example Security',
+    summary: 'Researchers discuss general awareness topics.',
+  });
+
+  assert.deepEqual(cues, ['SentryInsight: monitor']);
 });
 
 test('generateHTML renders facet filter controls and empty filtered state', () => {


### PR DESCRIPTION
## Summary
- Add deterministic downstream handoff cues to generated article cards.
- Render SentryInsight and GRCInsight cue chips without changing stored news data.

## Validation
- `npm test`