### PR TITLE
Add article age filtering

### DIFF
--- a/config/news-sources.json
+++ b/config/news-sources.json
@@ -33,7 +33,7 @@
   ],
   "settings": {
     "maxNewsItems": 30,
-    "lastUpdated": "2026-06-23T14:36:02.561Z",
+    "lastUpdated": "2026-06-23T14:47:18.685Z",
     "testTrigger": true,
     "manualTrigger": "2025-09-19T13:55:00.000Z",
     "sortMode": "recent"

--- a/feed-info.json
+++ b/feed-info.json
@@ -9,5 +9,5 @@
     "Bleeping Computer",
     "Dark Reading"
   ],
-  "lastUpdated": "2026-06-23T14:36:02.625Z"
+  "lastUpdated": "2026-06-23T14:47:18.745Z"
 }

--- a/feed.xml
+++ b/feed.xml
@@ -9,9 +9,9 @@
             <link>https://ricomanifesto.github.io/SentryDigest/</link>
         </image>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Tue, 23 Jun 2026 14:36:02 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 23 Jun 2026 14:47:18 GMT</lastBuildDate>
         <atom:link href="https://ricomanifesto.github.io/SentryDigest/feed.xml" rel="self" type="application/rss+xml"/>
-        <pubDate>Tue, 23 Jun 2026 14:36:02 GMT</pubDate>
+        <pubDate>Tue, 23 Jun 2026 14:47:18 GMT</pubDate>
         <language><![CDATA[en]]></language>
         <ttl>180</ttl>
         <comment>News aggregated from: Krebs on Security, The Hacker News, Threatpost, Bleeping Computer, Dark Reading</comment>

--- a/index.html
+++ b/index.html
@@ -131,22 +131,27 @@
         <option value="">All vendors</option>
         <option value="Fortinet">Fortinet</option><option value="GitHub">GitHub</option><option value="Google">Google</option><option value="Microsoft">Microsoft</option><option value="OpenAI">OpenAI</option>
       </select>
+      <select id="ageFilter" class="select" aria-label="Filter by article age">
+        <option value="">Any age</option>
+        <option value="Fresh">Fresh</option><option value="Recent">Recent</option>
+      </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T14:36:02.539Z">6/23/2026, 2:36:02 PM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T14:45:36.136Z">6/23/2026, 9:45:36 AM</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
       
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns" data-summary="GitHub is moving to strengthen software supply chain security by updating &quot;actions/checkout&quot; to block pwn request attacks that exploit the risky use of the &quot;pull_request_target workflow&quot; trigger to ru..." data-severity="Elevated" data-tags="Exploitation,Supply Chain" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns" data-summary="GitHub is moving to strengthen software supply chain security by updating &quot;actions/checkout&quot; to block pwn request attacks that exploit the risky use of the &quot;pull_request_target workflow&quot; trigger to ru..." data-severity="Elevated" data-tags="Exploitation,Supply Chain" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 23m old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html" target="_blank" rel="noopener">GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T14:22:03.000Z">June 23, 2026 at 2:22 PM</time>
+            <time datetime="2026-06-23T14:22:03.000Z">June 23, 2026 at 9:22 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Exploitation</span><span class="chip">Supply Chain</span></div>
@@ -159,16 +164,17 @@
             <p class="news-summary summary-full" id="summary-full-0">&quot;pull_request_target workflow&quot; trigger to ru...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="The Exploit Doesn&#39;t Exist. You Can Still Prove It Works Against You" data-summary="Attackers can now weaponize newly disclosed vulnerabilities far faster than most organizations can patch them. Picus Security explains how security teams can validate exploitability before a public ex..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="The Exploit Doesn&#39;t Exist. You Can Still Prove It Works Against You" data-summary="Attackers can now weaponize newly disclosed vulnerabilities far faster than most organizations can patch them. Picus Security explains how security teams can validate exploitability before a public ex..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 44m old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/the-exploit-doesnt-exist-you-can-still-prove-it-works-against-you/" target="_blank" rel="noopener">The Exploit Doesn&#39;t Exist. You Can Still Prove It Works Against You</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T14:01:11.000Z">June 23, 2026 at 2:01 PM</time>
+            <time datetime="2026-06-23T14:01:11.000Z">June 23, 2026 at 9:01 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
@@ -181,16 +187,17 @@
             <p class="news-summary summary-full" id="summary-full-1">validate exploitability before a public ex...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="LastPass confirms data breach in Klue supply chain attack" data-summary="LastPass announced that hackers accessed customer data from its Salesforce environment after stealing the company&#39;s OAuth tokens in the Klue supply chain attack earlier this month. [...]..." data-severity="Critical" data-tags="Data Breach,Identity,Supply Chain" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="LastPass confirms data breach in Klue supply chain attack" data-summary="LastPass announced that hackers accessed customer data from its Salesforce environment after stealing the company&#39;s OAuth tokens in the Klue supply chain attack earlier this month. [...]..." data-severity="Critical" data-tags="Data Breach,Identity,Supply Chain" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 47m old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/lastpass-confirms-data-breach-in-klue-supply-chain-attack/" target="_blank" rel="noopener">LastPass confirms data breach in Klue supply chain attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T13:58:25.000Z">June 23, 2026 at 1:58 PM</time>
+            <time datetime="2026-06-23T13:58:25.000Z">June 23, 2026 at 8:58 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span><span class="chip">Supply Chain</span></div>
@@ -203,31 +210,33 @@
             <p class="news-summary summary-full" id="summary-full-2">attack earlier this month. [...]...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="SocGholish Takedown Highlights Malicious TDS Threats" data-summary="SocGholish uses traffic distribution systems (TDSs) to provide initial access into victims&#39; networks for cybercrime groups such as the notorious Evil Corp...." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
+        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="SocGholish Takedown Highlights Malicious TDS Threats" data-summary="SocGholish uses traffic distribution systems (TDSs) to provide initial access into victims&#39; networks for cybercrime groups such as the notorious Evil Corp...." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
             <span class="chip">darkreading.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 54m old</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyber-risk/socgholish-takedown-malicious-tds-threats" target="_blank" rel="noopener">SocGholish Takedown Highlights Malicious TDS Threats</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T13:51:33.000Z">June 23, 2026 at 1:51 PM</time>
+            <time datetime="2026-06-23T13:51:33.000Z">June 23, 2026 at 8:51 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
           <p class="news-summary">SocGholish uses traffic distribution systems (TDSs) to provide initial access into victims&#39; networks for cybercrime groups such as the notorious Evil Corp....</p>
         </article>
-        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist" data-summary="The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global campaign...." data-severity="Elevated" data-tags="Identity" data-vendors="Fortinet" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch,SentryInsight: vendor watch">
+        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist" data-summary="The threat actors engineered a Golang-based sniffer to target 430,000 FortiGate firewalls and identify 110 million credentials in the ongoing global campaign...." data-severity="Elevated" data-tags="Identity" data-vendors="Fortinet" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch,SentryInsight: vendor watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
             <span class="chip">darkreading.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 2h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/fortibleed-attackers-firewalls-credentials-stealers" target="_blank" rel="noopener">FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 12:34 PM</time>
+            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 7:34 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Identity</span></div>
@@ -240,16 +249,17 @@
             <p class="news-summary summary-full" id="summary-full-4">campaign....</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Webinar: Why email security teams are drowning in alerts" data-summary="Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl..." data-severity="Elevated" data-tags="Identity,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Webinar: Why email security teams are drowning in alerts" data-summary="Phishing, BEC, and account takeover attacks continue to overwhelm security teams with alerts and investigations. This webinar explores how behavioral AI can help automate detection and response workfl..." data-severity="Elevated" data-tags="Identity,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 2h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/webinar-why-email-security-teams-are-drowning-in-alerts/" target="_blank" rel="noopener">Webinar: Why email security teams are drowning in alerts</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 12:12 PM</time>
+            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 7:12 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">AI Security</span></div>
@@ -262,16 +272,17 @@
             <p class="news-summary summary-full" id="summary-full-5">help automate detection and response workfl...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Agentic AI: The Weapon That No Longer Needs a Warrior" data-summary="Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Agentic AI: The Weapon That No Longer Needs a Warrior" data-summary="Every weapon begins as an extension of the hand that holds it. The spear lengthened the reach of the arm. The bow sent the point flying without the throw. The rifle placed a man&#39;s death a quarter mile..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 3h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/agentic-ai-weapon-that-no-longer-needs.html" target="_blank" rel="noopener">Agentic AI: The Weapon That No Longer Needs a Warrior</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 11:30 AM</time>
+            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 6:30 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
@@ -289,16 +300,17 @@
 The list of identified packages, is below -
 
 
-  aes-..." data-severity="Elevated" data-tags="Malware,Supply Chain" data-vendors="Microsoft" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
+  aes-..." data-severity="Elevated" data-tags="Malware,Supply Chain" data-vendors="Microsoft" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 5h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/malicious-npm-packages-pose-as-postcss.html" target="_blank" rel="noopener">Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 8:54 AM</time>
+            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 3:54 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
@@ -316,16 +328,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
   aes-...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool" data-summary="Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool" data-summary="Direct messages sent via WhatsApp are being used to distribute malicious Visual Basic Script (VBScript) files that lead to the installation of legitimate Remote Monitoring and Management (RMM) softwar..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 9h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/whatsapp-vbscript-campaign-uses-fake.html" target="_blank" rel="noopener">WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 5:38 AM</time>
+            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 12:38 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -337,16 +350,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-8">Remote Monitoring and Management (RMM) softwar...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws" data-summary="OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="OpenAI" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws" data-summary="OpenAI on Monday said it&#39;s releasing an improved version of its GPT‑5.5‑Cyber model to trusted defenders as part of the Daybreak initiative the artificial intelligence (AI) company announced last mont..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="OpenAI" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 10h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/openai-expands-daybreak-with-gpt-55.html" target="_blank" rel="noopener">OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T03:56:58.000Z">June 23, 2026 at 3:56 AM</time>
+            <time datetime="2026-06-23T03:56:58.000Z">June 22, 2026 at 10:56 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">OpenAI</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -359,16 +373,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-9">intelligence (AI) company announced last mont...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="WhatsApp phishing attack uses fake business docs to hack PCs" data-summary="An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]..." data-severity="Elevated" data-tags="Identity,Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="WhatsApp phishing attack uses fake business docs to hack PCs" data-summary="An ongoing malware campaign is targeting WhatsApp users in multiple countries with deceptive messages that push VBScript files, leading to remote system access. [...]..." data-severity="Elevated" data-tags="Identity,Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 16h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/whatsapp-phishing-attack-uses-fake-business-docs-to-hack-pcs/" target="_blank" rel="noopener">WhatsApp phishing attack uses fake business docs to hack PCs</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 10:42 PM</time>
+            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 5:42 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">Malware</span></div>
@@ -381,16 +396,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-10">access. [...]...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="JaredFromSubway MEV bot hacked in $15 million crypto theft" data-summary="The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="JaredFromSubway MEV bot hacked in $15 million crypto theft" data-summary="The JaredFromSubway Ethereum MEV (Maximal Extractable Value) bot suffered a $15 million loss after an attacker manipulated the opportunity-detection logic by creating fake cryptocurrency trading oppor..." data-severity="Monitor" data-tags="" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 16h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/jaredfromsubway-mev-bot-hacked-in-15-million-crypto-theft/" target="_blank" rel="noopener">JaredFromSubway MEV bot hacked in $15 million crypto theft</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 9:52 PM</time>
+            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 4:52 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -402,16 +418,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-11">creating fake cryptocurrency trading oppor...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories" data-summary="Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data...." data-severity="Elevated" data-tags="Vulnerability,Exploitation,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage">
+        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories" data-summary="Four vulnerabilities allow attackers to exploit Dify, a platform for AI application building and management, to silently access and exfiltrate sensitive data...." data-severity="Elevated" data-tags="Vulnerability,Exploitation,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
             <span class="chip">darkreading.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 17h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/application-security/difytap-bugs-wiretap-ai-chat-histories" target="_blank" rel="noopener">DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 9:14 PM</time>
+            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 4:14 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span><span class="chip">AI Security</span></div>
@@ -424,16 +441,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-12">data....</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FFmpeg fixes PixelSmash flaw in widely used video decoder" data-summary="A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FFmpeg fixes PixelSmash flaw in widely used video decoder" data-summary="A newly disclosed FFmpeg flaw dubbed &#39;PixelSmash&#39; could be exploited for remote code execution on Jellyfin servers under certain conditions, and can also trigger a denial-of-service  condition in appl..." data-severity="Elevated" data-tags="Vulnerability,Exploitation" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 17h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/ffmpeg-fixes-pixelsmash-flaw-in-widely-used-video-decoder/" target="_blank" rel="noopener">FFmpeg fixes PixelSmash flaw in widely used video decoder</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 9:05 PM</time>
+            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 4:05 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
@@ -446,16 +464,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-13">trigger a denial-of-service  condition in appl...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FortiBleed campaign used custom FortiGate sniffer to steal credentials" data-summary="Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="Fortinet" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch,SentryInsight: vendor watch">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="FortiBleed campaign used custom FortiGate sniffer to steal credentials" data-summary="Security firm SOCRadar says the large-scale FortiBleed campaign targeting Fortinet FortiGate devices used custom sniffers to harvest authentication secrets from compromised firewalls and steal credent..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="Fortinet" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch,SentryInsight: vendor watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 18h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/fortibleed-campaign-used-custom-fortigate-sniffer-to-steal-credentials/" target="_blank" rel="noopener">FortiBleed campaign used custom FortiGate sniffer to steal credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 8:01 PM</time>
+            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 3:01 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
@@ -470,16 +489,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack" data-summary="Multiple WordPress plugins from ShapedPlugin were compromised in a supply chain attack after unknown threat actors managed to tamper with the official release channels and push backdoor code.
 
-&quot;Attack..." data-severity="Elevated" data-tags="Malware,Supply Chain" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
+&quot;Attack..." data-severity="Elevated" data-tags="Malware,Supply Chain" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 20h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/shapedplugin-wordpress-pro-plugins.html" target="_blank" rel="noopener">ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 6:00 PM</time>
+            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 1:00 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
@@ -494,16 +514,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
 &quot;Attack...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft says Windows 11 26H2 is coming soon, details upgrade process" data-summary="Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]..." data-severity="Monitor" data-tags="" data-vendors="Microsoft" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft says Windows 11 26H2 is coming soon, details upgrade process" data-summary="Microsoft has confirmed that Windows 11 version 26H2 will be the next feature update and that devices running Windows 11 24H2 and 25H2 will be able to upgrade using a small enablement package. [...]..." data-severity="Monitor" data-tags="" data-vendors="Microsoft" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 21h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/microsoft/microsoft-says-windows-11-26h2-is-coming-soon-details-upgrade-process/" target="_blank" rel="noopener">Microsoft says Windows 11 26H2 is coming soon, details upgrade process</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 5:41 PM</time>
+            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 12:41 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span></div>
@@ -516,16 +537,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-16">using a small enablement package. [...]...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft fixes AutoGen Studio flaw that enabled code execution" data-summary="A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="Microsoft" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="Microsoft fixes AutoGen Studio flaw that enabled code execution" data-summary="A vulnerability chain dubbed AutoJack in Microsoft&#39;s AutoGen Studio interface for prototyping AI agents could let attackers manipulate an agent into executing arbitrary commands on its host system sim..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="Microsoft" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 21h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/microsoft-fixes-autogen-studio-flaw-that-enabled-code-execution/" target="_blank" rel="noopener">Microsoft fixes AutoGen Studio flaw that enabled code execution</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 5:28 PM</time>
+            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 12:28 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -538,16 +560,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-17">arbitrary commands on its host system sim...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests" data-summary="A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests" data-summary="A heap over-read in the Squid web proxy can leak another user&#39;s cleartext HTTP request, including any credentials or session tokens it carries, to anyone already allowed to send traffic through the sa..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 22h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/29-year-old-squid-proxy-bug-squidbleed.html" target="_blank" rel="noopener">29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 4:29 PM</time>
+            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 11:29 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
@@ -560,16 +583,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-18">already allowed to send traffic through the sa...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants" data-summary="Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants" data-summary="Cybersecurity researchers have disclosed details of four vulnerabilities in Dify, an open-source agentic workflow platform with more than 146,000 GitHub stars, that could allow attackers to stealthily..." data-severity="Elevated" data-tags="Vulnerability,AI Security" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vuln triage,SentryInsight: vendor watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 22h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/researchers-detail-difytap-flaws-in.html" target="_blank" rel="noopener">Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 4:13 PM</time>
+            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 11:13 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -582,16 +606,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-19">that could allow attackers to stealthily...</p>
           </details>
         </article>
-        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign" data-summary="Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker...." data-severity="Monitor" data-tags="" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
+        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign" data-summary="Attackers are using multiple online channels — including GitHub, YouTube, and VirusTotal — to build an illusion of trust to spread a cross-platform clipboard hijacker...." data-severity="Monitor" data-tags="" data-vendors="GitHub" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch" data-age-bucket="Fresh">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
             <span class="chip">darkreading.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Fresh - 22h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/crypto-heist-fake-reputation-boosting-campaign" target="_blank" rel="noopener">Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 4:10 PM</time>
+            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 11:10 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span></div>
@@ -604,16 +629,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-20">hijacker....</p>
           </details>
         </article>
-        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="He Thought He Was Secure; His Phone Number Got Stolen Anyway" data-summary="Threat actors can easily steal one-time passwords sent by text when they conduct a SIM swap attack. This can lead to account takeovers, so users must layer up their security measures...." data-severity="Elevated" data-tags="Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
+        <article class="news-item" data-source="Dark Reading" data-host="darkreading.com" data-title="He Thought He Was Secure; His Phone Number Got Stolen Anyway" data-summary="Threat actors can easily steal one-time passwords sent by text when they conduct a SIM swap attack. This can lead to account takeovers, so users must layer up their security measures...." data-severity="Elevated" data-tags="Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch" data-age-bucket="Recent">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
             <span class="chip">darkreading.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Recent - 1d old</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyber-risk/how-a-sim-swap-attack-led-to-a-near-account-takeover" target="_blank" rel="noopener">He Thought He Was Secure; His Phone Number Got Stolen Anyway</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:12:11.000Z">June 22, 2026 at 2:12 PM</time>
+            <time datetime="2026-06-22T14:12:11.000Z">June 22, 2026 at 9:12 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Identity</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
@@ -625,16 +651,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <p class="news-summary summary-full" id="summary-full-21">their security measures....</p>
           </details>
         </article>
-        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="A Glimpse into the “Search Your Target” Market for Stolen Credentials" data-summary="Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
+        <article class="news-item" data-source="Bleeping Computer" data-host="bleepingcomputer.com" data-title="A Glimpse into the “Search Your Target” Market for Stolen Credentials" data-summary="Attackers no longer need to sift through massive credential dumps. They can pay others to do it for them. Flare explores how an emerging underground market searches stolen credential databases for spe..." data-severity="Critical" data-tags="Data Breach,Identity" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch" data-age-bucket="Recent">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Recent - 1d old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/a-glimpse-into-the-search-your-target-market-for-stolen-credentials/" target="_blank" rel="noopener">A Glimpse into the “Search Your Target” Market for Stolen Credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 2:05 PM</time>
+            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 9:05 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
@@ -648,16 +675,17 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer" data-summary="Cybersecurity researchers have disclosed details of a new campaign that delivers CastleStealer by means of a previously unreported malware loader dubbed OXLOADER.
 
-According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Malware" data-vendors="Google" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
+According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Malware" data-vendors="Google" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch" data-age-bucket="Recent">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Recent - 1d old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/new-oxloader-loader-uses-malicious.html" target="_blank" rel="noopener">New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 1:20 PM</time>
+            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 8:20 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
@@ -673,16 +701,17 @@ According to Elastic Security Labs, ...</p>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries" data-summary="Google has set September 30, 2026, as the day it begins enforcing Android developer verification in the first four countries, and the major device-maker app stores are in from the start.
 
-On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch">
+On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data-source-signal="Industry media" data-handoff-cues="SentryInsight: vendor watch" data-age-bucket="Recent">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Recent - 1d old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/google-sets-sept-30-deadline-for.html" target="_blank" rel="noopener">Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 12:45 PM</time>
+            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 7:45 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
@@ -696,16 +725,17 @@ On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data
 On that date...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Stop Your Legacy Infrastructure from Hijacking Your AI Agents" data-summary="Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Stop Your Legacy Infrastructure from Hijacking Your AI Agents" data-summary="Earlier this month, I spoke at the Gartner Security &amp; Risk Management Summit about a blind spot most security programs are still not accounting for - how attackers are circumventing AI security progra..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor" data-age-bucket="Recent">
           <div class="chips">
             <span class="severity severity-monitor">Monitor</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Recent - 1d old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/stop-your-legacy-infrastructure-from.html" target="_blank" rel="noopener">Stop Your Legacy Infrastructure from Hijacking Your AI Agents</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 11:58 AM</time>
+            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 6:58 AM</time>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -719,16 +749,17 @@ On that date...</p>
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More" data-summary="It’s Monday again.
 
-This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down security tools, and mobile malware asking..." data-severity="Critical" data-tags="Ransomware,Vulnerability,Malware" data-vendors="Google" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch,SentryInsight: vuln triage,SentryInsight: vendor watch">
+This week’s threat list looks painfully familiar: abused integrations, fake tools, poisoned websites, ransomware crews trying to shut down security tools, and mobile malware asking..." data-severity="Critical" data-tags="Ransomware,Vulnerability,Malware" data-vendors="Google" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch,SentryInsight: vuln triage,SentryInsight: vendor watch" data-age-bucket="Recent">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Recent - 1d old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/weekly-recap-browser-bugs-edr-killers.html" target="_blank" rel="noopener">⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 10:55 AM</time>
+            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 5:55 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Ransomware</span><span class="chip">Vulnerability</span><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
@@ -744,16 +775,17 @@ This week’s threat list looks painfully familiar: abused integrations, fake to
         </article>
         <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices" data-summary="Canada&#39;s spy service got a judge&#39;s permission to reach into infected servers, home routers, and IoT gear sitting on Canadian soil and neutralize two foreign-run botnets.
 
-The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
+The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor" data-age-bucket="Recent">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Recent - 1d old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/canadas-spy-agency-used-first-of-its.html" target="_blank" rel="noopener">Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 9:11 AM</time>
+            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 4:11 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -767,16 +799,17 @@ The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" 
 The Federal Court released a ...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network" data-summary="A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network" data-summary="A new malware family is turning forgotten home routers into a distributed reconnaissance and proxy network, not the DDoS botnet these devices usually end up in. QiAnXin&#39;s XLab calls it AryStinger and ..." data-severity="Elevated" data-tags="Malware" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: monitor" data-age-bucket="Recent">
           <div class="chips">
             <span class="severity severity-elevated">Elevated</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Recent - 1d old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/arystinger-malware-infects-4300-legacy.html" target="_blank" rel="noopener">AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 6:57 AM</time>
+            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 1:57 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -788,16 +821,17 @@ The Federal Court released a ...</p>
             <p class="news-summary summary-full" id="summary-full-28">in. QiAnXin&#39;s XLab calls it AryStinger and ...</p>
           </details>
         </article>
-        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific" data-summary="A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne..." data-severity="Critical" data-tags="Ransomware,Identity,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch">
+        <article class="news-item" data-source="The Hacker News" data-host="thehackernews.com" data-title="INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific" data-summary="A new report from INTERPOL has revealed a &quot;dramatic increase&quot; in cybercrime in Asia and the South Pacific, fueled by rapid digitalization, internet penetration, new technologies, organized criminal ne..." data-severity="Critical" data-tags="Ransomware,Identity,AI Security" data-vendors="" data-source-signal="Industry media" data-handoff-cues="SentryInsight: incident watch" data-age-bucket="Recent">
           <div class="chips">
             <span class="severity severity-critical">Critical</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
+            <span class="chip age-chip">Recent - 1d old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/interpol-warns-phishing-ransomware-and.html" target="_blank" rel="noopener">INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 6:06 AM</time>
+            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 1:06 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span><span class="chip">Identity</span><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
@@ -840,6 +874,7 @@ The Federal Court released a ...</p>
       const severityFilter = q('#severityFilter');
       const tagFilter = q('#tagFilter');
       const vendorFilter = q('#vendorFilter');
+      const ageFilter = q('#ageFilter');
       const emptyFilteredState = q('#emptyFilteredState');
       const stats = q('#stats');
       const cards = qa('.news-item');
@@ -850,6 +885,7 @@ The Federal Court released a ...</p>
         const severity = severityFilter && severityFilter.value || '';
         const tag = tagFilter && tagFilter.value || '';
         const vendor = vendorFilter && vendorFilter.value || '';
+        const age = ageFilter && ageFilter.value || '';
         let visible = 0;
         cards.forEach(card => {
           const matchesText = !term || (card.getAttribute('data-title').toLowerCase().includes(term) || card.getAttribute('data-summary').toLowerCase().includes(term));
@@ -857,17 +893,18 @@ The Federal Court released a ...</p>
           const matchesSeverity = !severity || card.getAttribute('data-severity') === severity;
           const matchesTag = !tag || card.getAttribute('data-tags').split(',').filter(Boolean).includes(tag);
           const matchesVendor = !vendor || card.getAttribute('data-vendors').split(',').filter(Boolean).includes(vendor);
-          const show = matchesText && matchesSource && matchesSeverity && matchesTag && matchesVendor;
+          const matchesAge = !age || card.getAttribute('data-age-bucket') === age;
+          const show = matchesText && matchesSource && matchesSeverity && matchesTag && matchesVendor && matchesAge;
           card.style.display = show ? '' : 'none';
           if (show) visible++;
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T14:36:02.539Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T14:45:36.136Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));
-      [sourceFilter, severityFilter, tagFilter, vendorFilter].forEach(function(filter){
+      [sourceFilter, severityFilter, tagFilter, vendorFilter, ageFilter].forEach(function(filter){
         if (filter) filter.addEventListener('change', update);
       });
 

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
         <option value="Fresh">Fresh</option><option value="Recent">Recent</option>
       </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T14:45:36.136Z">6/23/2026, 9:45:36 AM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T14:47:18.658Z">6/23/2026, 2:47:18 PM</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
@@ -147,11 +147,11 @@
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 23m old</span>
+            <span class="chip age-chip">Fresh - 25m old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html" target="_blank" rel="noopener">GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T14:22:03.000Z">June 23, 2026 at 9:22 AM</time>
+            <time datetime="2026-06-23T14:22:03.000Z">June 23, 2026 at 2:22 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Exploitation</span><span class="chip">Supply Chain</span></div>
@@ -170,11 +170,11 @@
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 44m old</span>
+            <span class="chip age-chip">Fresh - 46m old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/the-exploit-doesnt-exist-you-can-still-prove-it-works-against-you/" target="_blank" rel="noopener">The Exploit Doesn&#39;t Exist. You Can Still Prove It Works Against You</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T14:01:11.000Z">June 23, 2026 at 9:01 AM</time>
+            <time datetime="2026-06-23T14:01:11.000Z">June 23, 2026 at 2:01 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
@@ -193,11 +193,11 @@
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 47m old</span>
+            <span class="chip age-chip">Fresh - 48m old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/lastpass-confirms-data-breach-in-klue-supply-chain-attack/" target="_blank" rel="noopener">LastPass confirms data breach in Klue supply chain attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T13:58:25.000Z">June 23, 2026 at 8:58 AM</time>
+            <time datetime="2026-06-23T13:58:25.000Z">June 23, 2026 at 1:58 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span><span class="chip">Supply Chain</span></div>
@@ -216,11 +216,11 @@
             <span class="chip"><span class="dot"></span>Dark Reading</span>
             <span class="chip">darkreading.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 54m old</span>
+            <span class="chip age-chip">Fresh - 55m old</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyber-risk/socgholish-takedown-malicious-tds-threats" target="_blank" rel="noopener">SocGholish Takedown Highlights Malicious TDS Threats</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T13:51:33.000Z">June 23, 2026 at 8:51 AM</time>
+            <time datetime="2026-06-23T13:51:33.000Z">June 23, 2026 at 1:51 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -236,7 +236,7 @@
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/fortibleed-attackers-firewalls-credentials-stealers" target="_blank" rel="noopener">FortiBleed Attackers Turn Firewalls Into Credential Stealers as Heists Persist</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 7:34 AM</time>
+            <time datetime="2026-06-23T12:34:54.000Z">June 23, 2026 at 12:34 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Identity</span></div>
@@ -259,7 +259,7 @@
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/webinar-why-email-security-teams-are-drowning-in-alerts/" target="_blank" rel="noopener">Webinar: Why email security teams are drowning in alerts</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 7:12 AM</time>
+            <time datetime="2026-06-23T12:12:20.000Z">June 23, 2026 at 12:12 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">AI Security</span></div>
@@ -282,7 +282,7 @@
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/agentic-ai-weapon-that-no-longer-needs.html" target="_blank" rel="noopener">Agentic AI: The Weapon That No Longer Needs a Warrior</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 6:30 AM</time>
+            <time datetime="2026-06-23T11:30:00.000Z">June 23, 2026 at 11:30 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
@@ -310,7 +310,7 @@ The list of identified packages, is below -
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/malicious-npm-packages-pose-as-postcss.html" target="_blank" rel="noopener">Malicious npm Packages Pose as PostCSS Tools to Deliver Windows RAT</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 3:54 AM</time>
+            <time datetime="2026-06-23T08:54:32.000Z">June 23, 2026 at 8:54 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
@@ -338,7 +338,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/whatsapp-vbscript-campaign-uses-fake.html" target="_blank" rel="noopener">WhatsApp VBScript Campaign Uses Fake Documents to Install ManageEngine RMM Tool</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 12:38 AM</time>
+            <time datetime="2026-06-23T05:38:40.000Z">June 23, 2026 at 5:38 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -360,7 +360,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/openai-expands-daybreak-with-gpt-55.html" target="_blank" rel="noopener">OpenAI Expands Daybreak With GPT-5.5-Cyber to Help Defenders Patch Security Flaws</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-23T03:56:58.000Z">June 22, 2026 at 10:56 PM</time>
+            <time datetime="2026-06-23T03:56:58.000Z">June 23, 2026 at 3:56 AM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">OpenAI</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -383,7 +383,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/whatsapp-phishing-attack-uses-fake-business-docs-to-hack-pcs/" target="_blank" rel="noopener">WhatsApp phishing attack uses fake business docs to hack PCs</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 5:42 PM</time>
+            <time datetime="2026-06-22T22:42:21.000Z">June 22, 2026 at 10:42 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Identity</span><span class="chip">Malware</span></div>
@@ -406,7 +406,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/jaredfromsubway-mev-bot-hacked-in-15-million-crypto-theft/" target="_blank" rel="noopener">JaredFromSubway MEV bot hacked in $15 million crypto theft</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 4:52 PM</time>
+            <time datetime="2026-06-22T21:52:18.000Z">June 22, 2026 at 9:52 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -428,7 +428,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/application-security/difytap-bugs-wiretap-ai-chat-histories" target="_blank" rel="noopener">DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 4:14 PM</time>
+            <time datetime="2026-06-22T21:14:11.000Z">June 22, 2026 at 9:14 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span><span class="chip">AI Security</span></div>
@@ -451,7 +451,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/ffmpeg-fixes-pixelsmash-flaw-in-widely-used-video-decoder/" target="_blank" rel="noopener">FFmpeg fixes PixelSmash flaw in widely used video decoder</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 4:05 PM</time>
+            <time datetime="2026-06-22T21:05:01.000Z">June 22, 2026 at 9:05 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Vulnerability</span><span class="chip">Exploitation</span></div>
@@ -474,7 +474,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/fortibleed-campaign-used-custom-fortigate-sniffer-to-steal-credentials/" target="_blank" rel="noopener">FortiBleed campaign used custom FortiGate sniffer to steal credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 3:01 PM</time>
+            <time datetime="2026-06-22T20:01:02.000Z">June 22, 2026 at 8:01 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Fortinet</span><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
@@ -499,7 +499,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/shapedplugin-wordpress-pro-plugins.html" target="_blank" rel="noopener">ShapedPlugin WordPress Pro Plugins Backdoored in Supply Chain Attack</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 1:00 PM</time>
+            <time datetime="2026-06-22T18:00:48.000Z">June 22, 2026 at 6:00 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Malware</span><span class="chip">Supply Chain</span></div>
@@ -524,7 +524,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/microsoft/microsoft-says-windows-11-26h2-is-coming-soon-details-upgrade-process/" target="_blank" rel="noopener">Microsoft says Windows 11 26H2 is coming soon, details upgrade process</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 12:41 PM</time>
+            <time datetime="2026-06-22T17:41:31.000Z">June 22, 2026 at 5:41 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span></div>
@@ -547,7 +547,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/microsoft-fixes-autogen-studio-flaw-that-enabled-code-execution/" target="_blank" rel="noopener">Microsoft fixes AutoGen Studio flaw that enabled code execution</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 12:28 PM</time>
+            <time datetime="2026-06-22T17:28:57.000Z">June 22, 2026 at 5:28 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Microsoft</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -570,7 +570,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/29-year-old-squid-proxy-bug-squidbleed.html" target="_blank" rel="noopener">29-Year-Old Squid Proxy Bug &#39;Squidbleed&#39; Can Leak Cleartext HTTP Requests</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 11:29 AM</time>
+            <time datetime="2026-06-22T16:29:00.000Z">June 22, 2026 at 4:29 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
@@ -593,7 +593,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/researchers-detail-difytap-flaws-in.html" target="_blank" rel="noopener">Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 11:13 AM</time>
+            <time datetime="2026-06-22T16:13:28.000Z">June 22, 2026 at 4:13 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span><span class="chip">Vulnerability</span><span class="chip">AI Security</span></div>
@@ -616,7 +616,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/crypto-heist-fake-reputation-boosting-campaign" target="_blank" rel="noopener">Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 11:10 AM</time>
+            <time datetime="2026-06-22T16:10:10.000Z">June 22, 2026 at 4:10 PM</time>
             <span class="badge-new">NEW</span>
           </div>
           <div class="facet-row"><span class="chip">GitHub</span></div>
@@ -639,7 +639,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyber-risk/how-a-sim-swap-attack-led-to-a-near-account-takeover" target="_blank" rel="noopener">He Thought He Was Secure; His Phone Number Got Stolen Anyway</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:12:11.000Z">June 22, 2026 at 9:12 AM</time>
+            <time datetime="2026-06-22T14:12:11.000Z">June 22, 2026 at 2:12 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Identity</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
@@ -661,7 +661,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/a-glimpse-into-the-search-your-target-market-for-stolen-credentials/" target="_blank" rel="noopener">A Glimpse into the “Search Your Target” Market for Stolen Credentials</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 9:05 AM</time>
+            <time datetime="2026-06-22T14:05:15.000Z">June 22, 2026 at 2:05 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Data Breach</span><span class="chip">Identity</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
@@ -685,7 +685,7 @@ According to Elastic Security Labs, ..." data-severity="Elevated" data-tags="Mal
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/new-oxloader-loader-uses-malicious.html" target="_blank" rel="noopener">New OXLOADER Loader Uses Malicious Google Ads to Deliver CastleStealer</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 8:20 AM</time>
+            <time datetime="2026-06-22T13:20:12.000Z">June 22, 2026 at 1:20 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
@@ -711,7 +711,7 @@ On that date..." data-severity="Monitor" data-tags="" data-vendors="Google" data
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/google-sets-sept-30-deadline-for.html" target="_blank" rel="noopener">Google Sets Sept. 30 Deadline for Android Developer Verification in Four Countries</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 7:45 AM</time>
+            <time datetime="2026-06-22T12:45:08.000Z">June 22, 2026 at 12:45 PM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: vendor watch</span></div>
@@ -735,7 +735,7 @@ On that date...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/stop-your-legacy-infrastructure-from.html" target="_blank" rel="noopener">Stop Your Legacy Infrastructure from Hijacking Your AI Agents</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 6:58 AM</time>
+            <time datetime="2026-06-22T11:58:00.000Z">June 22, 2026 at 11:58 AM</time>
           </div>
           <div class="facet-row"><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -759,7 +759,7 @@ This week’s threat list looks painfully familiar: abused integrations, fake to
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/weekly-recap-browser-bugs-edr-killers.html" target="_blank" rel="noopener">⚡ Weekly Recap: Browser Bugs, EDR Killers, TV Botnet, OpenBSD Flaw, Android Trojan, and More</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 5:55 AM</time>
+            <time datetime="2026-06-22T10:55:10.000Z">June 22, 2026 at 10:55 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Google</span><span class="chip">Ransomware</span><span class="chip">Vulnerability</span><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span><span class="handoff-cue">SentryInsight: vuln triage</span><span class="handoff-cue">SentryInsight: vendor watch</span></div>
@@ -785,7 +785,7 @@ The Federal Court released a ..." data-severity="Elevated" data-tags="Malware" 
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/canadas-spy-agency-used-first-of-its.html" target="_blank" rel="noopener">Canada’s Spy Agency Used First-of-Its-Kind Warrant to Clean Botnet-Infected Devices</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 4:11 AM</time>
+            <time datetime="2026-06-22T09:11:37.000Z">June 22, 2026 at 9:11 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -809,7 +809,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/arystinger-malware-infects-4300-legacy.html" target="_blank" rel="noopener">AryStinger Malware Infects 4,300 Legacy Routers to Build Reconnaissance Proxy Network</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 1:57 AM</time>
+            <time datetime="2026-06-22T06:57:44.000Z">June 22, 2026 at 6:57 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Malware</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: monitor</span></div>
@@ -831,7 +831,7 @@ The Federal Court released a ...</p>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/interpol-warns-phishing-ransomware-and.html" target="_blank" rel="noopener">INTERPOL Warns Phishing, Ransomware, and AI Scams Are Rising Across Asia-Pacific</a></h2>
           <div class="news-meta">
-            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 1:06 AM</time>
+            <time datetime="2026-06-22T06:06:53.000Z">June 22, 2026 at 6:06 AM</time>
           </div>
           <div class="facet-row"><span class="chip">Ransomware</span><span class="chip">Identity</span><span class="chip">AI Security</span></div>
           <div class="handoff-row" aria-label="Downstream handoff cues"><span class="handoff-cue">SentryInsight: incident watch</span></div>
@@ -900,7 +900,7 @@ The Federal Court released a ...</p>
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T14:45:36.136Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T14:47:18.658Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -88,6 +88,8 @@ const HANDOFF_CUE_RULES = [
   },
 ];
 
+const AGE_BUCKET_ORDER = ['Fresh', 'Recent', 'Older', 'Undated'];
+
 function matchesRule(text, rule) {
   return rule.pattern.test(text);
 }
@@ -135,16 +137,50 @@ function deriveHandoffCues(article) {
   return cues.length > 0 ? cues : ['SentryInsight: monitor'];
 }
 
-function collectFacetFilterOptions(newsItems) {
+function deriveAgeBucket(articleDate, generatedAt = new Date()) {
+  const date = new Date(articleDate);
+  const now = new Date(generatedAt);
+  if (!Number.isFinite(date.getTime()) || !Number.isFinite(now.getTime())) {
+    return {
+      label: 'Undated',
+      detail: 'date unavailable',
+    };
+  }
+
+  const ageMs = Math.max(0, now.getTime() - date.getTime());
+  const ageMinutes = Math.floor(ageMs / (60 * 1000));
+  const ageHours = Math.floor(ageMs / (60 * 60 * 1000));
+  const ageDays = Math.floor(ageMs / (24 * 60 * 60 * 1000));
+
+  const detail = ageHours < 1
+    ? `${ageMinutes}m old`
+    : ageHours < 24
+      ? `${ageHours}h old`
+      : `${ageDays}d old`;
+
+  if (ageHours < 24) {
+    return { label: 'Fresh', detail };
+  }
+
+  if (ageDays < 4) {
+    return { label: 'Recent', detail };
+  }
+
+  return { label: 'Older', detail };
+}
+
+function collectFacetFilterOptions(newsItems, generatedAt = new Date()) {
   const severities = new Set();
   const tags = new Set();
   const vendors = new Set();
+  const ageBuckets = new Set();
 
   newsItems.forEach((article) => {
     const facets = deriveArticleFacets(article);
     severities.add(facets.severity);
     facets.tags.forEach((tag) => tags.add(tag));
     facets.vendors.forEach((vendor) => vendors.add(vendor));
+    ageBuckets.add(deriveAgeBucket(article.date, generatedAt).label);
   });
 
   const severityOrder = ['Critical', 'Elevated', 'Monitor'];
@@ -152,6 +188,7 @@ function collectFacetFilterOptions(newsItems) {
     severities: severityOrder.filter((severity) => severities.has(severity)),
     tags: Array.from(tags).sort((left, right) => left.localeCompare(right)),
     vendors: Array.from(vendors).sort((left, right) => left.localeCompare(right)),
+    ageBuckets: AGE_BUCKET_ORDER.filter((bucket) => ageBuckets.has(bucket)),
   };
 }
 
@@ -218,10 +255,11 @@ function renderSummary(summary, index) {
           </details>`;
 }
 
-function renderArticleCard(article, index = 0) {
+function renderArticleCard(article, index = 0, generatedAt = new Date()) {
   const articleLink = safeArticleLink(article.link);
   const facets = deriveArticleFacets(article);
   const handoffCues = deriveHandoffCues(article);
+  const ageBucket = deriveAgeBucket(article.date, generatedAt);
   const hostname = (() => {
     try {
       return new URL(articleLink).hostname.replace(/^www\./, '');
@@ -248,6 +286,9 @@ function renderArticleCard(article, index = 0) {
   const safeTagsAttr = escapeAttribute(facets.tags.join(','));
   const safeVendorsAttr = escapeAttribute(facets.vendors.join(','));
   const safeHandoffCuesAttr = escapeAttribute(handoffCues.join(','));
+  const safeAgeBucket = escapeHtml(ageBucket.label);
+  const safeAgeBucketAttr = escapeAttribute(ageBucket.label);
+  const safeAgeDetail = escapeHtml(ageBucket.detail);
   const vendorChips = facets.vendors.map((vendor) => `<span class="chip">${escapeHtml(vendor)}</span>`).join('');
   const tagChips = facets.tags.map((tag) => `<span class="chip">${escapeHtml(tag)}</span>`).join('');
   const handoffCueChips = handoffCues.map((cue) => `<span class="handoff-cue">${escapeHtml(cue)}</span>`).join('');
@@ -258,11 +299,12 @@ function renderArticleCard(article, index = 0) {
   const summary = renderSummary(article.summary, index);
 
   return `
-        <article class="news-item" data-source="${safeSourceAttr}" data-host="${safeHostAttr}" data-title="${safeTitleAttr}" data-summary="${safeSummaryAttr}" data-severity="${safeSeverityAttr}" data-tags="${safeTagsAttr}" data-vendors="${safeVendorsAttr}" data-source-signal="${safeSourceSignalAttr}" data-handoff-cues="${safeHandoffCuesAttr}">
+        <article class="news-item" data-source="${safeSourceAttr}" data-host="${safeHostAttr}" data-title="${safeTitleAttr}" data-summary="${safeSummaryAttr}" data-severity="${safeSeverityAttr}" data-tags="${safeTagsAttr}" data-vendors="${safeVendorsAttr}" data-source-signal="${safeSourceSignalAttr}" data-handoff-cues="${safeHandoffCuesAttr}" data-age-bucket="${safeAgeBucketAttr}">
           <div class="chips">
             <span class="severity severity-${safeSeverityClass}">${safeSeverity}</span>
             <span class="chip"><span class="dot"></span>${safeSource}</span>${hostChip}
             <span class="chip">${safeSourceSignal}</span>
+            <span class="chip age-chip">${safeAgeBucket} - ${safeAgeDetail}</span>
           </div>
           <h2 class="news-title"><a href="${safeLink}" target="_blank" rel="noopener">${safeTitle}</a></h2>
           <div class="news-meta">
@@ -281,17 +323,20 @@ function renderEmptyState() {
       `;
 }
 
-function generateHTML(newsItems) {
+function generateHTML(newsItems, options = {}) {
+  const generatedAt = options.generatedAt || new Date();
   const uniqueSources = Array.from(new Set(newsItems.map((article) => article.source)));
   const totalItems = newsItems.length;
-  const filterOptions = collectFacetFilterOptions(newsItems);
+  const filterOptions = collectFacetFilterOptions(newsItems, generatedAt);
   const sourceOptions = renderSelectOptions(uniqueSources);
   const severityOptions = renderSelectOptions(filterOptions.severities);
   const tagOptions = renderSelectOptions(filterOptions.tags);
   const vendorOptions = renderSelectOptions(filterOptions.vendors);
-  const nowIso = new Date().toISOString();
+  const ageOptions = renderSelectOptions(filterOptions.ageBuckets);
+  const now = new Date(generatedAt);
+  const nowIso = now.toISOString();
   const articleCards = newsItems.length > 0
-    ? newsItems.map((article, index) => renderArticleCard(article, index)).join('')
+    ? newsItems.map((article, index) => renderArticleCard(article, index, generatedAt)).join('')
     : renderEmptyState();
 
   return `
@@ -427,8 +472,12 @@ function generateHTML(newsItems) {
         <option value="">All vendors</option>
         ${vendorOptions}
       </select>
+      <select id="ageFilter" class="select" aria-label="Filter by article age">
+        <option value="">Any age</option>
+        ${ageOptions}
+      </select>
     </div>
-    <div class="stats" id="stats">Showing ${totalItems} of ${totalItems} articles from ${uniqueSources.length} sources • Last updated <time datetime="${nowIso}">${new Date().toLocaleString()}</time></div>
+    <div class="stats" id="stats">Showing ${totalItems} of ${totalItems} articles from ${uniqueSources.length} sources • Last updated <time datetime="${nowIso}">${now.toLocaleString()}</time></div>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
@@ -464,6 +513,7 @@ function generateHTML(newsItems) {
       const severityFilter = q('#severityFilter');
       const tagFilter = q('#tagFilter');
       const vendorFilter = q('#vendorFilter');
+      const ageFilter = q('#ageFilter');
       const emptyFilteredState = q('#emptyFilteredState');
       const stats = q('#stats');
       const cards = qa('.news-item');
@@ -474,6 +524,7 @@ function generateHTML(newsItems) {
         const severity = severityFilter && severityFilter.value || '';
         const tag = tagFilter && tagFilter.value || '';
         const vendor = vendorFilter && vendorFilter.value || '';
+        const age = ageFilter && ageFilter.value || '';
         let visible = 0;
         cards.forEach(card => {
           const matchesText = !term || (card.getAttribute('data-title').toLowerCase().includes(term) || card.getAttribute('data-summary').toLowerCase().includes(term));
@@ -481,7 +532,8 @@ function generateHTML(newsItems) {
           const matchesSeverity = !severity || card.getAttribute('data-severity') === severity;
           const matchesTag = !tag || card.getAttribute('data-tags').split(',').filter(Boolean).includes(tag);
           const matchesVendor = !vendor || card.getAttribute('data-vendors').split(',').filter(Boolean).includes(vendor);
-          const show = matchesText && matchesSource && matchesSeverity && matchesTag && matchesVendor;
+          const matchesAge = !age || card.getAttribute('data-age-bucket') === age;
+          const show = matchesText && matchesSource && matchesSeverity && matchesTag && matchesVendor && matchesAge;
           card.style.display = show ? '' : 'none';
           if (show) visible++;
         });
@@ -491,7 +543,7 @@ function generateHTML(newsItems) {
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));
-      [sourceFilter, severityFilter, tagFilter, vendorFilter].forEach(function(filter){
+      [sourceFilter, severityFilter, tagFilter, vendorFilter, ageFilter].forEach(function(filter){
         if (filter) filter.addEventListener('change', update);
       });
 
@@ -507,6 +559,7 @@ function generateHTML(newsItems) {
 
 module.exports = {
   collectFacetFilterOptions,
+  deriveAgeBucket,
   deriveArticleFacets,
   deriveHandoffCues,
   escapeHtml,

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -89,6 +89,7 @@ const HANDOFF_CUE_RULES = [
 ];
 
 const AGE_BUCKET_ORDER = ['Fresh', 'Recent', 'Older', 'Undated'];
+const INVALID_FEED_DATE_FALLBACK_TIME = new Date('1970-01-01T00:00:00.000Z').getTime();
 
 function matchesRule(text, rule) {
   return rule.pattern.test(text);
@@ -140,14 +141,15 @@ function deriveHandoffCues(article) {
 function deriveAgeBucket(articleDate, generatedAt = new Date()) {
   const date = new Date(articleDate);
   const now = new Date(generatedAt);
-  if (!Number.isFinite(date.getTime()) || !Number.isFinite(now.getTime())) {
+  const dateTime = date.getTime();
+  if (!Number.isFinite(dateTime) || dateTime === INVALID_FEED_DATE_FALLBACK_TIME || !Number.isFinite(now.getTime())) {
     return {
       label: 'Undated',
       detail: 'date unavailable',
     };
   }
 
-  const ageMs = Math.max(0, now.getTime() - date.getTime());
+  const ageMs = Math.max(0, now.getTime() - dateTime);
   const ageMinutes = Math.floor(ageMs / (60 * 1000));
   const ageHours = Math.floor(ageMs / (60 * 60 * 1000));
   const ageDays = Math.floor(ageMs / (24 * 60 * 60 * 1000));

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -377,6 +377,10 @@ test('deriveAgeBucket returns deterministic operator age buckets', () => {
     label: 'Undated',
     detail: 'date unavailable',
   });
+  assert.deepEqual(deriveAgeBucket(INVALID_FEED_DATE_FALLBACK, generatedAt), {
+    label: 'Undated',
+    detail: 'date unavailable',
+  });
 });
 
 test('generateHTML renders age metadata and filter controls', () => {
@@ -406,6 +410,22 @@ test('generateHTML renders age metadata and filter controls', () => {
   assert.match(html, /const ageFilter = q\('#ageFilter'\)/);
   assert.match(html, /card.getAttribute\('data-age-bucket'\) === age/);
   assert.match(html, /\[sourceFilter, severityFilter, tagFilter, vendorFilter, ageFilter\]/);
+});
+
+test('generateHTML treats the malformed feed date fallback as undated', () => {
+  const html = generateHTML([
+    {
+      title: 'Malformed date feed item',
+      link: 'https://example.com/malformed-date',
+      date: INVALID_FEED_DATE_FALLBACK,
+      source: 'Example Security',
+      summary: 'A feed item without a usable publication date.',
+    },
+  ], { generatedAt: new Date('2026-06-17T18:00:00.000Z') });
+
+  assert.match(html, /data-age-bucket="Undated"/);
+  assert.match(html, /<span class="chip age-chip">Undated - date unavailable<\/span>/);
+  assert.match(html, /<option value="Undated">Undated<\/option>/);
 });
 
 test('generateHTML renders facet filter controls and empty filtered state', () => {

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -9,6 +9,7 @@ const {
 const {
   collectFacetFilterOptions,
   deriveArticleFacets,
+  deriveAgeBucket,
   deriveHandoffCues,
   generateHTML,
 } = require('../scripts/render-news-html');
@@ -355,6 +356,56 @@ test('deriveHandoffCues returns a stable monitor cue for low-signal articles', (
   });
 
   assert.deepEqual(cues, ['SentryInsight: monitor']);
+});
+
+test('deriveAgeBucket returns deterministic operator age buckets', () => {
+  const generatedAt = new Date('2026-06-17T18:00:00.000Z');
+
+  assert.deepEqual(deriveAgeBucket(new Date('2026-06-17T17:30:00.000Z'), generatedAt), {
+    label: 'Fresh',
+    detail: '30m old',
+  });
+  assert.deepEqual(deriveAgeBucket(new Date('2026-06-16T18:00:00.000Z'), generatedAt), {
+    label: 'Recent',
+    detail: '1d old',
+  });
+  assert.deepEqual(deriveAgeBucket(new Date('2026-06-13T17:59:00.000Z'), generatedAt), {
+    label: 'Older',
+    detail: '4d old',
+  });
+  assert.deepEqual(deriveAgeBucket(new Date('invalid'), generatedAt), {
+    label: 'Undated',
+    detail: 'date unavailable',
+  });
+});
+
+test('generateHTML renders age metadata and filter controls', () => {
+  const html = generateHTML([
+    {
+      title: 'Fresh VPN exploitation story',
+      link: 'https://example.com/fresh-vpn',
+      date: new Date('2026-06-17T17:30:00.000Z'),
+      source: 'Example Security',
+      summary: 'Attackers are exploiting a VPN vulnerability.',
+    },
+    {
+      title: 'Older governance roundup',
+      link: 'https://example.com/older-governance',
+      date: new Date('2026-06-13T18:00:00.000Z'),
+      source: 'Example Security',
+      summary: 'Governance teams review audit findings.',
+    },
+  ], { generatedAt: new Date('2026-06-17T18:00:00.000Z') });
+
+  assert.match(html, /data-age-bucket="Fresh"/);
+  assert.match(html, /data-age-bucket="Older"/);
+  assert.match(html, /<span class="chip age-chip">Fresh - 30m old<\/span>/);
+  assert.match(html, /<select id="ageFilter" class="select" aria-label="Filter by article age">/);
+  assert.match(html, /<option value="Fresh">Fresh<\/option>/);
+  assert.match(html, /<option value="Older">Older<\/option>/);
+  assert.match(html, /const ageFilter = q\('#ageFilter'\)/);
+  assert.match(html, /card.getAttribute\('data-age-bucket'\) === age/);
+  assert.match(html, /\[sourceFilter, severityFilter, tagFilter, vendorFilter, ageFilter\]/);
 });
 
 test('generateHTML renders facet filter controls and empty filtered state', () => {


### PR DESCRIPTION
## Summary
- Add deterministic age buckets to generated article cards.
- Add an age filter that composes with the existing digest filters.

## Validation
- `npm test`