### PR TITLE
Add RSS source coverage

### DIFF
--- a/config/news-sources.json
+++ b/config/news-sources.json
@@ -33,7 +33,7 @@
   ],
   "settings": {
     "maxNewsItems": 30,
-    "lastUpdated": "2026-06-23T15:07:46.733Z",
+    "lastUpdated": "2026-06-23T15:20:21.686Z",
     "testTrigger": true,
     "manualTrigger": "2025-09-19T13:55:00.000Z",
     "sortMode": "recent"

--- a/feed-info.json
+++ b/feed-info.json
@@ -9,5 +9,5 @@
     "Bleeping Computer",
     "Dark Reading"
   ],
-  "lastUpdated": "2026-06-23T15:07:46.784Z"
+  "lastUpdated": "2026-06-23T15:20:21.754Z"
 }

--- a/feed.xml
+++ b/feed.xml
@@ -9,9 +9,9 @@
             <link>https://ricomanifesto.github.io/SentryDigest/</link>
         </image>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Tue, 23 Jun 2026 15:07:46 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 23 Jun 2026 15:20:21 GMT</lastBuildDate>
         <atom:link href="https://ricomanifesto.github.io/SentryDigest/feed.xml" rel="self" type="application/rss+xml"/>
-        <pubDate>Tue, 23 Jun 2026 15:07:46 GMT</pubDate>
+        <pubDate>Tue, 23 Jun 2026 15:20:21 GMT</pubDate>
         <language><![CDATA[en]]></language>
         <ttl>180</ttl>
         <comment>News aggregated from: Krebs on Security, The Hacker News, Threatpost, Bleeping Computer, Dark Reading</comment>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,13 @@
     .btn { border: 1px solid var(--card-border); background: var(--card); color: var(--fg); padding: 8px 10px; border-radius: 10px; cursor: pointer; }
     .btn:hover { border-color: var(--accent); }
     .stats { color: var(--muted); font-size: 0.9rem; margin-top: 6px; }
+    .source-coverage { align-items: center; background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; display: flex; flex-wrap: wrap; gap: 10px 12px; margin-top: 12px; padding: 10px 12px; }
+    .source-coverage-label { color: var(--muted); font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
+    .source-counts { display: flex; flex: 1 1 260px; flex-wrap: wrap; gap: 8px; }
+    .source-count { background: var(--chip); border-radius: 999px; color: var(--fg); font-size: 12px; padding: 4px 10px; }
+    .source-count strong { color: var(--accent); margin-left: 4px; }
+    .source-coverage a { color: var(--accent); font-size: 0.9rem; font-weight: 600; text-decoration: none; }
+    .source-coverage a:hover { text-decoration: underline; }
     .empty-filtered { background: var(--card); border: 1px dashed var(--card-border); border-radius: 10px; color: var(--muted); margin-top: 18px; padding: 18px; text-align: center; }
     .empty-filtered[hidden] { display: none; }
     .news-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; margin-top: 18px; }
@@ -137,6 +144,11 @@
       </select>
     </div>
     <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T15:07:46.711Z">6/23/2026, 3:07:46 PM</time></div>
+    <section class="source-coverage" aria-label="RSS source coverage">
+      <div class="source-coverage-label">RSS source coverage</div>
+      <div class="source-counts"><span class="source-count" data-source="The Hacker News">The Hacker News <strong>15</strong></span><span class="source-count" data-source="Bleeping Computer">Bleeping Computer <strong>10</strong></span><span class="source-count" data-source="Dark Reading">Dark Reading <strong>5</strong></span></div>
+      <a href="./feed.xml">RSS feed</a>
+    </section>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
@@ -915,4 +927,3 @@ The Federal Court released a ...</p>
   </script>
 </body>
 </html>
-  

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
         <option value="Fresh">Fresh</option><option value="Recent">Recent</option>
       </select>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T15:07:46.711Z">6/23/2026, 3:07:46 PM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 3 sources • Last updated <time datetime="2026-06-23T15:20:21.657Z">6/23/2026, 3:20:21 PM</time></div>
     <section class="source-coverage" aria-label="RSS source coverage">
       <div class="source-coverage-label">RSS source coverage</div>
       <div class="source-counts"><span class="source-count" data-source="The Hacker News">The Hacker News <strong>15</strong></span><span class="source-count" data-source="Bleeping Computer">Bleeping Computer <strong>10</strong></span><span class="source-count" data-source="Dark Reading">Dark Reading <strong>5</strong></span></div>
@@ -159,7 +159,7 @@
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 45m old</span>
+            <span class="chip age-chip">Fresh - 58m old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html" target="_blank" rel="noopener">GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns</a></h2>
           <div class="news-meta">
@@ -267,7 +267,7 @@
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 2h old</span>
+            <span class="chip age-chip">Fresh - 3h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/webinar-why-email-security-teams-are-drowning-in-alerts/" target="_blank" rel="noopener">Webinar: Why email security teams are drowning in alerts</a></h2>
           <div class="news-meta">
@@ -436,7 +436,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
             <span class="chip">darkreading.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 17h old</span>
+            <span class="chip age-chip">Fresh - 18h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/application-security/difytap-bugs-wiretap-ai-chat-histories" target="_blank" rel="noopener">DifyTap Bugs Let Attackers &#39;Wiretap&#39; AI Chat Histories</a></h2>
           <div class="news-meta">
@@ -601,7 +601,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 22h old</span>
+            <span class="chip age-chip">Fresh - 23h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/researchers-detail-difytap-flaws-in.html" target="_blank" rel="noopener">Researchers Detail DifyTap Flaws in Dify That Could Expose AI Chats Across Tenants</a></h2>
           <div class="news-meta">
@@ -624,7 +624,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
             <span class="chip"><span class="dot"></span>Dark Reading</span>
             <span class="chip">darkreading.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 22h old</span>
+            <span class="chip age-chip">Fresh - 23h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/cyberattacks-data-breaches/crypto-heist-fake-reputation-boosting-campaign" target="_blank" rel="noopener">Crypto Heist Fueled by Elaborate Fake Reputation-Boosting Campaign</a></h2>
           <div class="news-meta">
@@ -912,7 +912,7 @@ The Federal Court released a ...</p>
         });
         const total = 30;
         const srcCount = 3;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T15:07:46.711Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T15:20:21.657Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
       }
       if (search) search.addEventListener('input', debounce(update, 120));
@@ -927,3 +927,4 @@ The Federal Court released a ...</p>
   </script>
 </body>
 </html>
+  

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -194,10 +194,39 @@ function collectFacetFilterOptions(newsItems, generatedAt = new Date()) {
   };
 }
 
+function collectSourceCoverage(newsItems) {
+  const counts = new Map();
+  newsItems.forEach((article) => {
+    const source = article.source || 'Unknown source';
+    counts.set(source, (counts.get(source) || 0) + 1);
+  });
+
+  return Array.from(counts.entries())
+    .map(([source, count]) => ({ source, count }))
+    .sort((left, right) => right.count - left.count || left.source.localeCompare(right.source));
+}
+
 function renderSelectOptions(values) {
   return values
     .map((value) => `<option value="${escapeAttribute(value)}">${escapeHtml(value)}</option>`)
     .join('');
+}
+
+function renderSourceCoverage(newsItems) {
+  const sourceCounts = collectSourceCoverage(newsItems);
+  if (sourceCounts.length === 0) {
+    return '';
+  }
+
+  const sourceCountItems = sourceCounts
+    .map(({ source, count }) => `<span class="source-count" data-source="${escapeAttribute(source)}">${escapeHtml(source)} <strong>${count}</strong></span>`)
+    .join('');
+
+  return `<section class="source-coverage" aria-label="RSS source coverage">
+      <div class="source-coverage-label">RSS source coverage</div>
+      <div class="source-counts">${sourceCountItems}</div>
+      <a href="./feed.xml">RSS feed</a>
+    </section>`;
 }
 
 const SUMMARY_PREVIEW_LENGTH = 160;
@@ -337,6 +366,7 @@ function generateHTML(newsItems, options = {}) {
   const ageOptions = renderSelectOptions(filterOptions.ageBuckets);
   const now = new Date(generatedAt);
   const nowIso = now.toISOString();
+  const sourceCoverage = renderSourceCoverage(newsItems);
   const articleCards = newsItems.length > 0
     ? newsItems.map((article, index) => renderArticleCard(article, index, generatedAt)).join('')
     : renderEmptyState();
@@ -390,6 +420,13 @@ function generateHTML(newsItems, options = {}) {
     .btn { border: 1px solid var(--card-border); background: var(--card); color: var(--fg); padding: 8px 10px; border-radius: 10px; cursor: pointer; }
     .btn:hover { border-color: var(--accent); }
     .stats { color: var(--muted); font-size: 0.9rem; margin-top: 6px; }
+    .source-coverage { align-items: center; background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; display: flex; flex-wrap: wrap; gap: 10px 12px; margin-top: 12px; padding: 10px 12px; }
+    .source-coverage-label { color: var(--muted); font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
+    .source-counts { display: flex; flex: 1 1 260px; flex-wrap: wrap; gap: 8px; }
+    .source-count { background: var(--chip); border-radius: 999px; color: var(--fg); font-size: 12px; padding: 4px 10px; }
+    .source-count strong { color: var(--accent); margin-left: 4px; }
+    .source-coverage a { color: var(--accent); font-size: 0.9rem; font-weight: 600; text-decoration: none; }
+    .source-coverage a:hover { text-decoration: underline; }
     .empty-filtered { background: var(--card); border: 1px dashed var(--card-border); border-radius: 10px; color: var(--muted); margin-top: 18px; padding: 18px; text-align: center; }
     .empty-filtered[hidden] { display: none; }
     .news-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; margin-top: 18px; }
@@ -480,6 +517,7 @@ function generateHTML(newsItems, options = {}) {
       </select>
     </div>
     <div class="stats" id="stats">Showing ${totalItems} of ${totalItems} articles from ${uniqueSources.length} sources • Last updated <time datetime="${nowIso}">${now.toLocaleString()}</time></div>
+    ${sourceCoverage}
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
 
     <div class="news-container" id="newsContainer">
@@ -561,6 +599,7 @@ function generateHTML(newsItems, options = {}) {
 
 module.exports = {
   collectFacetFilterOptions,
+  collectSourceCoverage,
   deriveAgeBucket,
   deriveArticleFacets,
   deriveHandoffCues,

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -8,6 +8,7 @@ const {
 } = require('../scripts/fetch-news');
 const {
   collectFacetFilterOptions,
+  collectSourceCoverage,
   deriveArticleFacets,
   deriveAgeBucket,
   deriveHandoffCues,
@@ -329,6 +330,37 @@ test('collectFacetFilterOptions returns deterministic severity, tag, and vendor 
   assert.deepEqual(options.vendors, ['Microsoft']);
 });
 
+test('collectSourceCoverage returns deterministic source counts', () => {
+  const coverage = collectSourceCoverage([
+    {
+      title: 'First story',
+      link: 'https://example.com/first',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example Security',
+      summary: 'Story one.',
+    },
+    {
+      title: 'Second story',
+      link: 'https://example.com/second',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example Security',
+      summary: 'Story two.',
+    },
+    {
+      title: 'Third story',
+      link: 'https://example.com/third',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Another Source',
+      summary: 'Story three.',
+    },
+  ]);
+
+  assert.deepEqual(coverage, [
+    { source: 'Example Security', count: 2 },
+    { source: 'Another Source', count: 1 },
+  ]);
+});
+
 test('deriveHandoffCues identifies downstream incident and governance relevance', () => {
   const cues = deriveHandoffCues({
     title: 'Microsoft Exchange zero-day exploited in data breach response',
@@ -410,6 +442,38 @@ test('generateHTML renders age metadata and filter controls', () => {
   assert.match(html, /const ageFilter = q\('#ageFilter'\)/);
   assert.match(html, /card.getAttribute\('data-age-bucket'\) === age/);
   assert.match(html, /\[sourceFilter, severityFilter, tagFilter, vendorFilter, ageFilter\]/);
+});
+
+test('generateHTML renders escaped source coverage and RSS clarity', () => {
+  const html = generateHTML([
+    {
+      title: 'First story',
+      link: 'https://example.com/first',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example <Security>',
+      summary: 'Story one.',
+    },
+    {
+      title: 'Second story',
+      link: 'https://example.com/second',
+      date: new Date('2026-06-17T17:00:00.000Z'),
+      source: 'Example <Security>',
+      summary: 'Story two.',
+    },
+    {
+      title: 'Third story',
+      link: 'https://example.com/third',
+      date: new Date('2026-06-17T16:00:00.000Z'),
+      source: 'Another Source',
+      summary: 'Story three.',
+    },
+  ], { generatedAt: new Date('2026-06-17T18:00:00.000Z') });
+
+  assert.match(html, /<section class="source-coverage" aria-label="RSS source coverage">/);
+  assert.match(html, /<span class="source-count" data-source="Example &lt;Security&gt;">Example &lt;Security&gt; <strong>2<\/strong><\/span>/);
+  assert.match(html, /<span class="source-count" data-source="Another Source">Another Source <strong>1<\/strong><\/span>/);
+  assert.match(html, /<a href="\.\/feed\.xml">RSS feed<\/a>/);
+  assert.doesNotMatch(html, /Example <Security>/);
 });
 
 test('generateHTML treats the malformed feed date fallback as undated', () => {


### PR DESCRIPTION
## Summary
- Add a compact RSS source coverage strip with per-source article counts.
- Derive and escape source coverage in the static renderer.
- Add regression coverage for deterministic counts and rendered RSS clarity.

## Validation
- npm test