### PR TITLE
Add filter-aware operator lanes

### DIFF
--- a/config/news-sources.json
+++ b/config/news-sources.json
@@ -33,7 +33,7 @@
   ],
   "settings": {
     "maxNewsItems": 30,
-    "lastUpdated": "2026-06-23T22:07:12.994Z",
+    "lastUpdated": "2026-06-23T22:33:45.827Z",
     "testTrigger": true,
     "manualTrigger": "2025-09-19T13:55:00.000Z",
     "sortMode": "recent"

--- a/feed-info.json
+++ b/feed-info.json
@@ -9,5 +9,5 @@
     "Bleeping Computer",
     "Dark Reading"
   ],
-  "lastUpdated": "2026-06-23T22:07:13.054Z"
+  "lastUpdated": "2026-06-23T22:33:45.888Z"
 }

--- a/feed.xml
+++ b/feed.xml
@@ -9,9 +9,9 @@
             <link>https://ricomanifesto.github.io/SentryDigest/</link>
         </image>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Tue, 23 Jun 2026 22:07:13 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 23 Jun 2026 22:33:45 GMT</lastBuildDate>
         <atom:link href="https://ricomanifesto.github.io/SentryDigest/feed.xml" rel="self" type="application/rss+xml"/>
-        <pubDate>Tue, 23 Jun 2026 22:07:13 GMT</pubDate>
+        <pubDate>Tue, 23 Jun 2026 22:33:45 GMT</pubDate>
         <language><![CDATA[en]]></language>
         <ttl>180</ttl>
         <comment>News aggregated from: Krebs on Security, The Hacker News, Threatpost, Bleeping Computer, Dark Reading</comment>

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
       <div id="activeFilters" class="active-filters" hidden aria-live="polite"></div>
       <button id="resetFilters" class="btn reset-filters" type="button" hidden>Reset filters</button>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 4 sources • Last updated <time datetime="2026-06-23T22:07:13.054Z">6/23/2026, 10:07:13 PM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 4 sources • Last updated <time datetime="2026-06-23T22:33:45.790Z">6/23/2026, 10:33:45 PM</time></div>
     <div id="filterInsights" class="filter-insights" aria-live="polite"></div>
     <section class="source-coverage" aria-label="RSS source coverage">
       <div class="source-coverage-label">RSS source coverage</div>
@@ -200,7 +200,7 @@
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 18m old</span>
+            <span class="chip age-chip">Fresh - 45m old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/cisco-unified-cm-sme-flaw-cve-2026-20230-now-exploited-in-attacks/" target="_blank" rel="noopener">Cisco Unified CM flaw CVE-2026-20230 now exploited in attacks</a></h2>
           <div class="news-meta">
@@ -251,7 +251,7 @@
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 1h old</span>
+            <span class="chip age-chip">Fresh - 2h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/microsoft/windows-11-kb5095093-update-rolls-out-new-point-in-time-restore-feature/" target="_blank" rel="noopener">Windows 11 KB5095093 update rolls out new Point-in-Time restore feature</a></h2>
           <div class="news-meta">
@@ -297,7 +297,7 @@
             <span class="chip"><span class="dot"></span>Dark Reading</span>
             <span class="chip">darkreading.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 2h old</span>
+            <span class="chip age-chip">Fresh - 3h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.darkreading.com/application-security/cordyceps-malicious-pull-requests-developer-workflows" target="_blank" rel="noopener">&#39;Cordyceps&#39;: Mushrooming Malicious Pull Requests Threaten Developer Workflows</a></h2>
           <div class="news-meta">
@@ -320,7 +320,7 @@
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 3h old</span>
+            <span class="chip age-chip">Fresh - 4h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/new-macos-clickfix-attack-silently-mounts-dmgs-to-push-infostealer/" target="_blank" rel="noopener">New macOS ClickFix attack silently mounts DMGs to push infostealer</a></h2>
           <div class="news-meta">
@@ -343,7 +343,7 @@
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 3h old</span>
+            <span class="chip age-chip">Fresh - 4h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/fortibleed-targeted-fortigate-firewalls.html" target="_blank" rel="noopener">FortiBleed Targeted FortiGate Firewalls in 110 Million-Credential Harvesting Operation</a></h2>
           <div class="news-meta">
@@ -366,7 +366,7 @@
             <span class="chip"><span class="dot"></span>Krebs on Security</span>
             <span class="chip">krebsonsecurity.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 5h old</span>
+            <span class="chip age-chip">Fresh - 6h old</span>
           </div>
           <h2 class="news-title"><a href="https://krebsonsecurity.com/2026/06/scattered-spider-hackers-plead-guilty-on-day-1-of-trial/" target="_blank" rel="noopener">Scattered Spider Hackers Plead Guilty on Day 1 of Trial</a></h2>
           <div class="news-meta">
@@ -388,7 +388,7 @@
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 6h old</span>
+            <span class="chip age-chip">Fresh - 7h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/scattered-spider-members-plead-guilty-to-hacking-transport-for-london/" target="_blank" rel="noopener">Scattered Spider members plead guilty to hacking Transport for London</a></h2>
           <div class="news-meta">
@@ -406,7 +406,7 @@ Ever..." data-severity="Monitor" data-tags="AI Security" data-vendors="" data-so
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 6h old</span>
+            <span class="chip age-chip">Fresh - 7h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/fake-ai-agent-skill-passed-security.html" target="_blank" rel="noopener">Fake AI Agent Skill Passed Security Scans and Reportedly Reached 26,000 Agents</a></h2>
           <div class="news-meta">
@@ -433,7 +433,7 @@ Key establishment must..." data-severity="Monitor" data-tags="" data-vendors="" 
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 6h old</span>
+            <span class="chip age-chip">Fresh - 7h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/trump-order-sets-2030-deadline-for.html" target="_blank" rel="noopener">Trump Order Sets 2030 Deadline for Federal Post-Quantum Crypto Migration</a></h2>
           <div class="news-meta">
@@ -457,7 +457,7 @@ Key establishment must...</p>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 7h old</span>
+            <span class="chip age-chip">Fresh - 8h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html" target="_blank" rel="noopener">GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns</a></h2>
           <div class="news-meta">
@@ -565,7 +565,7 @@ Key establishment must...</p>
             <span class="chip"><span class="dot"></span>Bleeping Computer</span>
             <span class="chip">bleepingcomputer.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 9h old</span>
+            <span class="chip age-chip">Fresh - 10h old</span>
           </div>
           <h2 class="news-title"><a href="https://www.bleepingcomputer.com/news/security/webinar-why-email-security-teams-are-drowning-in-alerts/" target="_blank" rel="noopener">Webinar: Why email security teams are drowning in alerts</a></h2>
           <div class="news-meta">
@@ -588,7 +588,7 @@ Key establishment must...</p>
             <span class="chip"><span class="dot"></span>The Hacker News</span>
             <span class="chip">thehackernews.com</span>
             <span class="chip">Industry media</span>
-            <span class="chip age-chip">Fresh - 10h old</span>
+            <span class="chip age-chip">Fresh - 11h old</span>
           </div>
           <h2 class="news-title"><a href="https://thehackernews.com/2026/06/agentic-ai-weapon-that-no-longer-needs.html" target="_blank" rel="noopener">Agentic AI: The Weapon That No Longer Needs a Warrior</a></h2>
           <div class="news-meta">
@@ -1089,7 +1089,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
         });
         const total = 30;
         const srcCount = 4;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T22:07:13.054Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T22:33:45.790Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
         renderActiveFilters();
         renderFilterInsights(visibleCards);

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
       <div id="activeFilters" class="active-filters" hidden aria-live="polite"></div>
       <button id="resetFilters" class="btn reset-filters" type="button" hidden>Reset filters</button>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 4 sources • Last updated <time datetime="2026-06-23T22:07:12.961Z">6/23/2026, 10:07:12 PM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 4 sources • Last updated <time datetime="2026-06-23T22:07:13.054Z">6/23/2026, 10:07:13 PM</time></div>
     <div id="filterInsights" class="filter-insights" aria-live="polite"></div>
     <section class="source-coverage" aria-label="RSS source coverage">
       <div class="source-coverage-label">RSS source coverage</div>
@@ -176,18 +176,18 @@
       <a href="./feed.xml">RSS feed</a>
     </section>
     <section class="operator-lanes" aria-label="Operator scan lanes">
-      <article class="operator-lane" data-lane="Incident watch">
+      <article class="operator-lane" data-lane="Incident watch" data-lane-cue="SentryInsight: incident watch">
         <div class="operator-lane-heading">Incident watch</div>
-        <span class="operator-lane-count"><strong>9</strong> items</span>
-        <a href="https://www.bleepingcomputer.com/news/security/tata-electronics-confirms-cyberattack-as-hackers-leak-data/" class="operator-lane-link">Tata Electronics confirms cyberattack as hackers leak data</a>
-      </article><article class="operator-lane" data-lane="Vulnerability triage">
+        <span class="operator-lane-count" data-lane-count><strong>9</strong> items</span>
+        <a href="https://www.bleepingcomputer.com/news/security/tata-electronics-confirms-cyberattack-as-hackers-leak-data/" class="operator-lane-link" data-lane-link>Tata Electronics confirms cyberattack as hackers leak data</a>
+      </article><article class="operator-lane" data-lane="Vulnerability triage" data-lane-cue="SentryInsight: vuln triage">
         <div class="operator-lane-heading">Vulnerability triage</div>
-        <span class="operator-lane-count"><strong>7</strong> items</span>
-        <a href="https://www.bleepingcomputer.com/news/security/cisco-unified-cm-sme-flaw-cve-2026-20230-now-exploited-in-attacks/" class="operator-lane-link">Cisco Unified CM flaw CVE-2026-20230 now exploited in attacks</a>
-      </article><article class="operator-lane" data-lane="Governance watch">
+        <span class="operator-lane-count" data-lane-count><strong>7</strong> items</span>
+        <a href="https://www.bleepingcomputer.com/news/security/cisco-unified-cm-sme-flaw-cve-2026-20230-now-exploited-in-attacks/" class="operator-lane-link" data-lane-link>Cisco Unified CM flaw CVE-2026-20230 now exploited in attacks</a>
+      </article><article class="operator-lane" data-lane="Governance watch" data-lane-cue="GRCInsight: governance watch">
         <div class="operator-lane-heading">Governance watch</div>
-        <span class="operator-lane-count"><strong>0</strong> items</span>
-        <a href="#" class="operator-lane-link">No current match</a>
+        <span class="operator-lane-count" data-lane-count><strong>0</strong> items</span>
+        <a href="#" class="operator-lane-link" data-lane-link>No current match</a>
       </article>
     </section>
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>
@@ -900,6 +900,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
       const activeFilters = q('#activeFilters');
       const resetFilters = q('#resetFilters');
       const filterInsights = q('#filterInsights');
+      const operatorLanes = qa('.operator-lane');
       const stats = q('#stats');
       const cards = qa('.news-item');
       const filterParams = {
@@ -1037,6 +1038,30 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
         appendInsightGroup('Handoff', handoffCounts, 2);
       }
 
+      function updateOperatorLanes(visibleCards){
+        operatorLanes.forEach(function(lane){
+          const cue = lane.getAttribute('data-lane-cue');
+          const countTarget = lane.querySelector('[data-lane-count]');
+          const linkTarget = lane.querySelector('[data-lane-link]');
+          const matchingCards = visibleCards.filter(function(card){
+            return card.getAttribute('data-handoff-cues').split(',').filter(Boolean).includes(cue);
+          });
+          const itemLabel = matchingCards.length === 1 ? 'item' : 'items';
+          const latestLink = matchingCards[0] && matchingCards[0].querySelector('.news-title a');
+          if (countTarget) {
+            const strongCount = document.createElement('strong');
+            strongCount.textContent = matchingCards.length;
+            countTarget.textContent = '';
+            countTarget.appendChild(strongCount);
+            countTarget.appendChild(document.createTextNode(' ' + itemLabel));
+          }
+          if (linkTarget) {
+            linkTarget.textContent = latestLink ? latestLink.textContent : 'No current match';
+            linkTarget.setAttribute('href', latestLink ? latestLink.getAttribute('href') : '#');
+          }
+        });
+      }
+
       function update(){
         const term = (search && search.value || '').toLowerCase().trim();
         const src = sourceFilter && sourceFilter.value || '';
@@ -1064,10 +1089,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
         });
         const total = 30;
         const srcCount = 4;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T22:07:12.961Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T22:07:13.054Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
         renderActiveFilters();
         renderFilterInsights(visibleCards);
+        updateOperatorLanes(visibleCards);
         syncQueryState();
       }
       if (search) search.addEventListener('input', debounce(update, 120));

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -282,17 +282,18 @@ function renderOperatorLanes(newsItems) {
     return '';
   }
 
-  const laneCards = lanes.map((lane) => {
+  const laneCards = lanes.map((lane, index) => {
     const safeLabel = escapeHtml(lane.label);
     const safeLabelAttr = escapeAttribute(lane.label);
+    const safeCueAttr = escapeAttribute(OPERATOR_LANE_RULES[index].cue);
     const safeLatestTitle = lane.latestTitle ? escapeHtml(lane.latestTitle) : 'No current match';
     const safeLatestLink = escapeAttribute(lane.latestLink || '#');
     const itemLabel = lane.count === 1 ? 'item' : 'items';
 
-    return `<article class="operator-lane" data-lane="${safeLabelAttr}">
+    return `<article class="operator-lane" data-lane="${safeLabelAttr}" data-lane-cue="${safeCueAttr}">
         <div class="operator-lane-heading">${safeLabel}</div>
-        <span class="operator-lane-count"><strong>${lane.count}</strong> ${itemLabel}</span>
-        <a href="${safeLatestLink}" class="operator-lane-link">${safeLatestTitle}</a>
+        <span class="operator-lane-count" data-lane-count><strong>${lane.count}</strong> ${itemLabel}</span>
+        <a href="${safeLatestLink}" class="operator-lane-link" data-lane-link>${safeLatestTitle}</a>
       </article>`;
   }).join('');
 
@@ -666,6 +667,7 @@ function generateHTML(newsItems, options = {}) {
       const activeFilters = q('#activeFilters');
       const resetFilters = q('#resetFilters');
       const filterInsights = q('#filterInsights');
+      const operatorLanes = qa('.operator-lane');
       const stats = q('#stats');
       const cards = qa('.news-item');
       const filterParams = {
@@ -803,6 +805,30 @@ function generateHTML(newsItems, options = {}) {
         appendInsightGroup('Handoff', handoffCounts, 2);
       }
 
+      function updateOperatorLanes(visibleCards){
+        operatorLanes.forEach(function(lane){
+          const cue = lane.getAttribute('data-lane-cue');
+          const countTarget = lane.querySelector('[data-lane-count]');
+          const linkTarget = lane.querySelector('[data-lane-link]');
+          const matchingCards = visibleCards.filter(function(card){
+            return card.getAttribute('data-handoff-cues').split(',').filter(Boolean).includes(cue);
+          });
+          const itemLabel = matchingCards.length === 1 ? 'item' : 'items';
+          const latestLink = matchingCards[0] && matchingCards[0].querySelector('.news-title a');
+          if (countTarget) {
+            const strongCount = document.createElement('strong');
+            strongCount.textContent = matchingCards.length;
+            countTarget.textContent = '';
+            countTarget.appendChild(strongCount);
+            countTarget.appendChild(document.createTextNode(' ' + itemLabel));
+          }
+          if (linkTarget) {
+            linkTarget.textContent = latestLink ? latestLink.textContent : 'No current match';
+            linkTarget.setAttribute('href', latestLink ? latestLink.getAttribute('href') : '#');
+          }
+        });
+      }
+
       function update(){
         const term = (search && search.value || '').toLowerCase().trim();
         const src = sourceFilter && sourceFilter.value || '';
@@ -834,6 +860,7 @@ function generateHTML(newsItems, options = {}) {
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
         renderActiveFilters();
         renderFilterInsights(visibleCards);
+        updateOperatorLanes(visibleCards);
         syncQueryState();
       }
       if (search) search.addEventListener('input', debounce(update, 120));

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -613,7 +613,7 @@ test('generateHTML renders active filter summary and reset wiring', () => {
   assert.match(html, /resetFilters\.hidden = activeFiltersList\.length === 0/);
   assert.match(html, /resetFilters\.addEventListener\('click', function\(\)/);
   assert.match(html, /control\.value = ''/);
-  assert.match(html, /renderActiveFilters\(\);\s+renderFilterInsights\(visibleCards\);\s+syncQueryState\(\);/);
+  assert.match(html, /renderActiveFilters\(\);\s+renderFilterInsights\(visibleCards\);\s+updateOperatorLanes\(visibleCards\);\s+syncQueryState\(\);/);
 });
 
 test('generateHTML renders visible result context wiring', () => {
@@ -706,15 +706,47 @@ test('generateHTML renders escaped operator scan lanes', () => {
   ], { generatedAt: new Date('2026-06-17T18:00:00.000Z') });
 
   assert.match(html, /<section class="operator-lanes" aria-label="Operator scan lanes">/);
-  assert.match(html, /<article class="operator-lane" data-lane="Incident watch">/);
-  assert.match(html, /<article class="operator-lane" data-lane="Vulnerability triage">/);
-  assert.match(html, /<article class="operator-lane" data-lane="Governance watch">/);
-  assert.match(html, /<span class="operator-lane-count"><strong>1<\/strong> item<\/span>/);
+  assert.match(html, /<article class="operator-lane" data-lane="Incident watch" data-lane-cue="SentryInsight: incident watch">/);
+  assert.match(html, /<article class="operator-lane" data-lane="Vulnerability triage" data-lane-cue="SentryInsight: vuln triage">/);
+  assert.match(html, /<article class="operator-lane" data-lane="Governance watch" data-lane-cue="GRCInsight: governance watch">/);
+  assert.match(html, /<span class="operator-lane-count" data-lane-count><strong>1<\/strong> item<\/span>/);
+  assert.match(html, /<a href="https:\/\/example\.com\/incident" class="operator-lane-link" data-lane-link>Ransomware crew steals credentials from exchange<\/a>/);
   assert.match(html, /Ransomware crew steals credentials from exchange/);
   assert.match(html, /Cisco VPN vulnerability patched by vendor/);
   assert.match(html, /Regulator opens &lt;privacy&gt; compliance audit/);
-  assert.match(html, /<a href="#" class="operator-lane-link">Regulator opens &lt;privacy&gt; compliance audit<\/a>/);
+  assert.match(html, /<a href="#" class="operator-lane-link" data-lane-link>Regulator opens &lt;privacy&gt; compliance audit<\/a>/);
   assert.doesNotMatch(html, /javascript:alert/);
+});
+
+test('generateHTML renders filter-aware operator lane wiring', () => {
+  const html = generateHTML([
+    {
+      title: 'Ransomware crew steals credentials from exchange',
+      link: 'https://example.com/incident',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example Security',
+      summary: 'Incident response teams are investigating stolen credentials.',
+    },
+    {
+      title: 'Cisco VPN vulnerability patched by vendor',
+      link: 'https://example.com/vuln',
+      date: new Date('2026-06-17T17:00:00.000Z'),
+      source: 'Example Security',
+      summary: 'CVE-2026-1234 affects exposed appliances.',
+    },
+  ], { generatedAt: new Date('2026-06-17T18:00:00.000Z') });
+
+  assert.match(html, /const operatorLanes = qa\('\.operator-lane'\)/);
+  assert.match(html, /function updateOperatorLanes\(visibleCards\)/);
+  assert.match(html, /const cue = lane\.getAttribute\('data-lane-cue'\)/);
+  assert.match(html, /card\.getAttribute\('data-handoff-cues'\)\.split\(','\)\.filter\(Boolean\)\.includes\(cue\)/);
+  assert.match(html, /const strongCount = document\.createElement\('strong'\)/);
+  assert.match(html, /strongCount\.textContent = matchingCards\.length/);
+  assert.match(html, /countTarget\.appendChild\(strongCount\)/);
+  assert.match(html, /countTarget\.appendChild\(document\.createTextNode\(' ' \+ itemLabel\)\)/);
+  assert.match(html, /linkTarget\.textContent = latestLink \? latestLink\.textContent : 'No current match'/);
+  assert.match(html, /linkTarget\.setAttribute\('href', latestLink \? latestLink\.getAttribute\('href'\) : '#'\)/);
+  assert.match(html, /renderFilterInsights\(visibleCards\);\s+updateOperatorLanes\(visibleCards\);\s+syncQueryState\(\);/);
 });
 
 test('generateHTML treats the malformed feed date fallback as undated', () => {


### PR DESCRIPTION
## Summary
- Update operator scan lanes from the currently visible article set after filters change.
- Keep server-rendered lane defaults for static output while adding cue metadata for client-side refresh.
- Cover the generated lane wiring with regression tests.

## Validation
- npm test