### PR TITLE
Add source coverage filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,8 @@
     .source-coverage { align-items: center; background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; display: flex; flex-wrap: wrap; gap: 10px 12px; margin-top: 12px; padding: 10px 12px; }
     .source-coverage-label { color: var(--muted); font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
     .source-counts { display: flex; flex: 1 1 260px; flex-wrap: wrap; gap: 8px; }
-    .source-count { background: var(--chip); border-radius: 999px; color: var(--fg); font-size: 12px; padding: 4px 10px; }
+    .source-count { background: var(--chip); border: 1px solid transparent; border-radius: 999px; color: var(--fg); cursor: pointer; font: inherit; font-size: 12px; padding: 4px 10px; }
+    .source-count:hover, .source-count[aria-pressed="true"] { border-color: var(--accent); }
     .source-count strong { color: var(--accent); margin-left: 4px; }
     .source-coverage a { color: var(--accent); font-size: 0.9rem; font-weight: 600; text-decoration: none; }
     .source-coverage a:hover { text-decoration: underline; }
@@ -168,11 +169,11 @@
       <div id="activeFilters" class="active-filters" hidden aria-live="polite"></div>
       <button id="resetFilters" class="btn reset-filters" type="button" hidden>Reset filters</button>
     </div>
-    <div class="stats" id="stats">Showing 30 of 30 articles from 4 sources • Last updated <time datetime="2026-06-23T22:44:53.697Z">6/23/2026, 10:44:53 PM</time></div>
+    <div class="stats" id="stats">Showing 30 of 30 articles from 4 sources • Last updated <time datetime="2026-06-23T22:44:53.763Z">6/23/2026, 10:44:53 PM</time></div>
     <div id="filterInsights" class="filter-insights" aria-live="polite"></div>
     <section class="source-coverage" aria-label="RSS source coverage">
       <div class="source-coverage-label">RSS source coverage</div>
-      <div class="source-counts"><span class="source-count" data-source="Bleeping Computer">Bleeping Computer <strong>15</strong></span><span class="source-count" data-source="The Hacker News">The Hacker News <strong>9</strong></span><span class="source-count" data-source="Dark Reading">Dark Reading <strong>5</strong></span><span class="source-count" data-source="Krebs on Security">Krebs on Security <strong>1</strong></span></div>
+      <div class="source-counts"><button class="source-count" type="button" data-source-filter="Bleeping Computer" aria-pressed="false">Bleeping Computer <strong>15</strong></button><button class="source-count" type="button" data-source-filter="The Hacker News" aria-pressed="false">The Hacker News <strong>9</strong></button><button class="source-count" type="button" data-source-filter="Dark Reading" aria-pressed="false">Dark Reading <strong>5</strong></button><button class="source-count" type="button" data-source-filter="Krebs on Security" aria-pressed="false">Krebs on Security <strong>1</strong></button></div>
       <a href="./feed.xml">RSS feed</a>
     </section>
     <section class="operator-lanes" aria-label="Operator scan lanes">
@@ -900,6 +901,7 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
       const resetFilters = q('#resetFilters');
       const filterInsights = q('#filterInsights');
       const operatorLanes = qa('.operator-lane');
+      const sourceCoverageButtons = qa('[data-source-filter]');
       const stats = q('#stats');
       const cards = qa('.news-item');
       const filterParams = {
@@ -1088,8 +1090,11 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
         });
         const total = 30;
         const srcCount = 4;
-        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T22:44:53.697Z').toLocaleString());
+        if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('2026-06-23T22:44:53.763Z').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
+        sourceCoverageButtons.forEach(function(button){
+          button.setAttribute('aria-pressed', button.getAttribute('data-source-filter') === src ? 'true' : 'false');
+        });
         renderActiveFilters();
         renderFilterInsights(visibleCards);
         updateOperatorLanes(visibleCards);
@@ -1098,6 +1103,14 @@ The list of</span><span class="summary-ellipsis" aria-hidden="true">...</span>
       if (search) search.addEventListener('input', debounce(update, 120));
       [sourceFilter, severityFilter, tagFilter, vendorFilter, ageFilter, handoffFilter].forEach(function(filter){
         if (filter) filter.addEventListener('change', update);
+      });
+      sourceCoverageButtons.forEach(function(button){
+        button.addEventListener('click', function(){
+          if (!sourceFilter) return;
+          const source = button.getAttribute('data-source-filter') || '';
+          sourceFilter.value = sourceFilter.value === source ? '' : source;
+          update();
+        });
       });
       if (resetFilters) resetFilters.addEventListener('click', function(){
         Object.keys(filterControls).forEach(function(key){

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -266,7 +266,7 @@ function renderSourceCoverage(newsItems) {
   }
 
   const sourceCountItems = sourceCounts
-    .map(({ source, count }) => `<span class="source-count" data-source="${escapeAttribute(source)}">${escapeHtml(source)} <strong>${count}</strong></span>`)
+    .map(({ source, count }) => `<button class="source-count" type="button" data-source-filter="${escapeAttribute(source)}" aria-pressed="false">${escapeHtml(source)} <strong>${count}</strong></button>`)
     .join('');
 
   return `<section class="source-coverage" aria-label="RSS source coverage">
@@ -512,7 +512,8 @@ function generateHTML(newsItems, options = {}) {
     .source-coverage { align-items: center; background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; display: flex; flex-wrap: wrap; gap: 10px 12px; margin-top: 12px; padding: 10px 12px; }
     .source-coverage-label { color: var(--muted); font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
     .source-counts { display: flex; flex: 1 1 260px; flex-wrap: wrap; gap: 8px; }
-    .source-count { background: var(--chip); border-radius: 999px; color: var(--fg); font-size: 12px; padding: 4px 10px; }
+    .source-count { background: var(--chip); border: 1px solid transparent; border-radius: 999px; color: var(--fg); cursor: pointer; font: inherit; font-size: 12px; padding: 4px 10px; }
+    .source-count:hover, .source-count[aria-pressed="true"] { border-color: var(--accent); }
     .source-count strong { color: var(--accent); margin-left: 4px; }
     .source-coverage a { color: var(--accent); font-size: 0.9rem; font-weight: 600; text-decoration: none; }
     .source-coverage a:hover { text-decoration: underline; }
@@ -668,6 +669,7 @@ function generateHTML(newsItems, options = {}) {
       const resetFilters = q('#resetFilters');
       const filterInsights = q('#filterInsights');
       const operatorLanes = qa('.operator-lane');
+      const sourceCoverageButtons = qa('[data-source-filter]');
       const stats = q('#stats');
       const cards = qa('.news-item');
       const filterParams = {
@@ -858,6 +860,9 @@ function generateHTML(newsItems, options = {}) {
         const srcCount = ${uniqueSources.length};
         if (stats) stats.textContent = 'Showing ' + visible + ' of ' + total + ' articles from ' + srcCount + ' sources • Last updated ' + (new Date('${nowIso}').toLocaleString());
         if (emptyFilteredState) emptyFilteredState.hidden = visible !== 0;
+        sourceCoverageButtons.forEach(function(button){
+          button.setAttribute('aria-pressed', button.getAttribute('data-source-filter') === src ? 'true' : 'false');
+        });
         renderActiveFilters();
         renderFilterInsights(visibleCards);
         updateOperatorLanes(visibleCards);
@@ -866,6 +871,14 @@ function generateHTML(newsItems, options = {}) {
       if (search) search.addEventListener('input', debounce(update, 120));
       [sourceFilter, severityFilter, tagFilter, vendorFilter, ageFilter, handoffFilter].forEach(function(filter){
         if (filter) filter.addEventListener('change', update);
+      });
+      sourceCoverageButtons.forEach(function(button){
+        button.addEventListener('click', function(){
+          if (!sourceFilter) return;
+          const source = button.getAttribute('data-source-filter') || '';
+          sourceFilter.value = sourceFilter.value === source ? '' : source;
+          update();
+        });
       });
       if (resetFilters) resetFilters.addEventListener('click', function(){
         Object.keys(filterControls).forEach(function(key){

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -674,10 +674,36 @@ test('generateHTML renders escaped source coverage and RSS clarity', () => {
   ], { generatedAt: new Date('2026-06-17T18:00:00.000Z') });
 
   assert.match(html, /<section class="source-coverage" aria-label="RSS source coverage">/);
-  assert.match(html, /<span class="source-count" data-source="Example &lt;Security&gt;">Example &lt;Security&gt; <strong>2<\/strong><\/span>/);
-  assert.match(html, /<span class="source-count" data-source="Another Source">Another Source <strong>1<\/strong><\/span>/);
+  assert.match(html, /<button class="source-count" type="button" data-source-filter="Example &lt;Security&gt;" aria-pressed="false">Example &lt;Security&gt; <strong>2<\/strong><\/button>/);
+  assert.match(html, /<button class="source-count" type="button" data-source-filter="Another Source" aria-pressed="false">Another Source <strong>1<\/strong><\/button>/);
   assert.match(html, /<a href="\.\/feed\.xml">RSS feed<\/a>/);
   assert.doesNotMatch(html, /Example <Security>/);
+});
+
+test('generateHTML wires source coverage counts into the source filter', () => {
+  const html = generateHTML([
+    {
+      title: 'First story',
+      link: 'https://example.com/first',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example Security',
+      summary: 'Story one.',
+    },
+    {
+      title: 'Second story',
+      link: 'https://example.com/second',
+      date: new Date('2026-06-17T17:00:00.000Z'),
+      source: 'Another Source',
+      summary: 'Story two.',
+    },
+  ], { generatedAt: new Date('2026-06-17T18:00:00.000Z') });
+
+  assert.match(html, /const sourceCoverageButtons = qa\('\[data-source-filter\]'\)/);
+  assert.match(html, /sourceCoverageButtons\.forEach\(function\(button\)/);
+  assert.match(html, /const source = button\.getAttribute\('data-source-filter'\) \|\| ''/);
+  assert.match(html, /sourceFilter\.value = sourceFilter\.value === source \? '' : source/);
+  assert.match(html, /button\.setAttribute\('aria-pressed', button\.getAttribute\('data-source-filter'\) === src \? 'true' : 'false'\)/);
+  assert.match(html, /update\(\);/);
 });
 
 test('generateHTML renders escaped operator scan lanes', () => {


### PR DESCRIPTION
## Summary
- Turn source coverage counts into filter shortcuts.
- Keep source filtering on the existing source control and query-state path.
- Cover the generated source coverage wiring with regression tests.

## Validation
- `npm test`
- `git diff --check`