### PR TITLE
Show quiet enabled feeds

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,8 @@
     .source-counts { display: flex; flex: 1 1 260px; flex-wrap: wrap; gap: 8px; }
     .source-count { background: var(--chip); border: 1px solid transparent; border-radius: 999px; color: var(--fg); cursor: pointer; font: inherit; font-size: 12px; padding: 4px 10px; }
     .source-count:hover, .source-count[aria-pressed="true"] { border-color: var(--accent); }
+    .source-count-empty { color: var(--muted); cursor: default; opacity: 0.78; }
+    .source-count-empty:hover { border-color: transparent; }
     .source-count strong { color: var(--accent); margin-left: 4px; }
     .source-coverage a { color: var(--accent); font-size: 0.9rem; font-weight: 600; text-decoration: none; }
     .source-coverage a:hover { text-decoration: underline; }
@@ -173,7 +175,7 @@
     <div id="filterInsights" class="filter-insights" aria-live="polite"></div>
     <section class="source-coverage" aria-label="RSS source coverage">
       <div class="source-coverage-label">RSS source coverage</div>
-      <div class="source-counts"><button class="source-count" type="button" data-source-filter="Bleeping Computer" aria-pressed="false">Bleeping Computer <strong>15</strong></button><button class="source-count" type="button" data-source-filter="The Hacker News" aria-pressed="false">The Hacker News <strong>9</strong></button><button class="source-count" type="button" data-source-filter="Dark Reading" aria-pressed="false">Dark Reading <strong>5</strong></button><button class="source-count" type="button" data-source-filter="Krebs on Security" aria-pressed="false">Krebs on Security <strong>1</strong></button></div>
+      <div class="source-counts"><button class="source-count" type="button" data-source-filter="Bleeping Computer" aria-pressed="false">Bleeping Computer <strong>15</strong></button><button class="source-count" type="button" data-source-filter="The Hacker News" aria-pressed="false">The Hacker News <strong>9</strong></button><button class="source-count" type="button" data-source-filter="Dark Reading" aria-pressed="false">Dark Reading <strong>5</strong></button><button class="source-count" type="button" data-source-filter="Krebs on Security" aria-pressed="false">Krebs on Security <strong>1</strong></button><button class="source-count source-count-empty" type="button" data-source-filter="Threatpost" aria-pressed="false" aria-disabled="true" disabled>Threatpost <strong>0</strong></button></div>
       <a href="./feed.xml">RSS feed</a>
     </section>
     <section class="operator-lanes" aria-label="Operator scan lanes">

--- a/scripts/fetch-news.js
+++ b/scripts/fetch-news.js
@@ -168,7 +168,9 @@ async function main() {
     console.log(`Fetched ${newsItems.length} news items from ${sources.length} active sources`);
     
     // Generate HTML
-    const html = generateHTML(newsItems);
+    const html = generateHTML(newsItems, {
+      sourceNames: sources.map(source => source.name),
+    });
     
     // Write HTML to index.html
     fs.writeFileSync(indexHtmlPath, html);

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -225,8 +225,13 @@ function collectFacetFilterOptions(newsItems, generatedAt = new Date()) {
   };
 }
 
-function collectSourceCoverage(newsItems) {
+function collectSourceCoverage(newsItems, sourceNames = []) {
   const counts = new Map();
+  sourceNames.forEach((source) => {
+    if (source) {
+      counts.set(source, 0);
+    }
+  });
   newsItems.forEach((article) => {
     const source = article.source || 'Unknown source';
     counts.set(source, (counts.get(source) || 0) + 1);
@@ -259,14 +264,18 @@ function renderSelectOptions(values) {
     .join('');
 }
 
-function renderSourceCoverage(newsItems) {
-  const sourceCounts = collectSourceCoverage(newsItems);
+function renderSourceCoverage(newsItems, sourceNames = []) {
+  const sourceCounts = collectSourceCoverage(newsItems, sourceNames);
   if (sourceCounts.length === 0) {
     return '';
   }
 
   const sourceCountItems = sourceCounts
-    .map(({ source, count }) => `<button class="source-count" type="button" data-source-filter="${escapeAttribute(source)}" aria-pressed="false">${escapeHtml(source)} <strong>${count}</strong></button>`)
+    .map(({ source, count }) => {
+      const emptyClass = count === 0 ? ' source-count-empty' : '';
+      const disabledAttributes = count === 0 ? ' aria-disabled="true" disabled' : '';
+      return `<button class="source-count${emptyClass}" type="button" data-source-filter="${escapeAttribute(source)}" aria-pressed="false"${disabledAttributes}>${escapeHtml(source)} <strong>${count}</strong></button>`;
+    })
     .join('');
 
   return `<section class="source-coverage" aria-label="RSS source coverage">
@@ -435,6 +444,7 @@ function renderEmptyState() {
 
 function generateHTML(newsItems, options = {}) {
   const generatedAt = options.generatedAt || new Date();
+  const sourceNames = Array.isArray(options.sourceNames) ? options.sourceNames : [];
   const uniqueSources = Array.from(new Set(newsItems.map((article) => article.source)));
   const totalItems = newsItems.length;
   const filterOptions = collectFacetFilterOptions(newsItems, generatedAt);
@@ -446,7 +456,7 @@ function generateHTML(newsItems, options = {}) {
   const handoffOptions = renderSelectOptions(filterOptions.handoffCues);
   const now = new Date(generatedAt);
   const nowIso = now.toISOString();
-  const sourceCoverage = renderSourceCoverage(newsItems);
+  const sourceCoverage = renderSourceCoverage(newsItems, sourceNames);
   const operatorLanes = renderOperatorLanes(newsItems);
   const articleCards = newsItems.length > 0
     ? newsItems.map((article, index) => renderArticleCard(article, index, generatedAt)).join('')
@@ -514,6 +524,8 @@ function generateHTML(newsItems, options = {}) {
     .source-counts { display: flex; flex: 1 1 260px; flex-wrap: wrap; gap: 8px; }
     .source-count { background: var(--chip); border: 1px solid transparent; border-radius: 999px; color: var(--fg); cursor: pointer; font: inherit; font-size: 12px; padding: 4px 10px; }
     .source-count:hover, .source-count[aria-pressed="true"] { border-color: var(--accent); }
+    .source-count-empty { color: var(--muted); cursor: default; opacity: 0.78; }
+    .source-count-empty:hover { border-color: transparent; }
     .source-count strong { color: var(--accent); margin-left: 4px; }
     .source-coverage a { color: var(--accent); font-size: 0.9rem; font-weight: 600; text-decoration: none; }
     .source-coverage a:hover { text-decoration: underline; }

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -376,6 +376,23 @@ test('collectSourceCoverage returns deterministic source counts', () => {
   ]);
 });
 
+test('collectSourceCoverage includes configured sources with zero articles', () => {
+  const coverage = collectSourceCoverage([
+    {
+      title: 'First story',
+      link: 'https://example.com/first',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example Security',
+      summary: 'Story one.',
+    },
+  ], ['Quiet Feed', 'Example Security']);
+
+  assert.deepEqual(coverage, [
+    { source: 'Example Security', count: 1 },
+    { source: 'Quiet Feed', count: 0 },
+  ]);
+});
+
 test('deriveHandoffCues identifies downstream incident and governance relevance', () => {
   const cues = deriveHandoffCues({
     title: 'Microsoft Exchange zero-day exploited in data breach response',
@@ -678,6 +695,25 @@ test('generateHTML renders escaped source coverage and RSS clarity', () => {
   assert.match(html, /<button class="source-count" type="button" data-source-filter="Another Source" aria-pressed="false">Another Source <strong>1<\/strong><\/button>/);
   assert.match(html, /<a href="\.\/feed\.xml">RSS feed<\/a>/);
   assert.doesNotMatch(html, /Example <Security>/);
+});
+
+test('generateHTML renders quiet configured feeds as inert source coverage chips', () => {
+  const html = generateHTML([
+    {
+      title: 'First story',
+      link: 'https://example.com/first',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example <Security>',
+      summary: 'Story one.',
+    },
+  ], {
+    generatedAt: new Date('2026-06-17T18:00:00.000Z'),
+    sourceNames: ['Quiet <Feed>', 'Example <Security>'],
+  });
+
+  assert.match(html, /<button class="source-count" type="button" data-source-filter="Example &lt;Security&gt;" aria-pressed="false">Example &lt;Security&gt; <strong>1<\/strong><\/button>/);
+  assert.match(html, /<button class="source-count source-count-empty" type="button" data-source-filter="Quiet &lt;Feed&gt;" aria-pressed="false" aria-disabled="true" disabled>Quiet &lt;Feed&gt; <strong>0<\/strong><\/button>/);
+  assert.doesNotMatch(html, /Quiet <Feed>/);
 });
 
 test('generateHTML wires source coverage counts into the source filter', () => {


### PR DESCRIPTION
## Summary
- Include enabled feeds with zero current articles in source coverage.
- Render zero-count feed chips as disabled source coverage entries.
- Pass enabled source names into generated HTML from the fetch path.

## Validation
- `npm test`
- `git diff --check`