### PR TITLE
Show RSS feed item count

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,8 @@
     .source-count strong { color: var(--accent); margin-left: 4px; }
     .source-coverage a { color: var(--accent); font-size: 0.9rem; font-weight: 600; text-decoration: none; }
     .source-coverage a:hover { text-decoration: underline; }
+    .feed-link { align-items: center; display: inline-flex; gap: 6px; }
+    .feed-link-count { background: var(--chip); border-radius: 999px; color: var(--muted); font-size: 12px; padding: 2px 8px; }
     .operator-lanes { display: grid; gap: 12px; grid-template-columns: repeat(3, minmax(0, 1fr)); margin-top: 14px; }
     .operator-lane { background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; display: grid; gap: 6px; padding: 12px; }
     .operator-lane-heading { font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
@@ -176,7 +178,7 @@
     <section class="source-coverage" aria-label="RSS source coverage">
       <div class="source-coverage-label">RSS source coverage</div>
       <div class="source-counts"><button class="source-count" type="button" data-source-filter="Bleeping Computer" aria-pressed="false">Bleeping Computer <strong>15</strong></button><button class="source-count" type="button" data-source-filter="The Hacker News" aria-pressed="false">The Hacker News <strong>9</strong></button><button class="source-count" type="button" data-source-filter="Dark Reading" aria-pressed="false">Dark Reading <strong>5</strong></button><button class="source-count" type="button" data-source-filter="Krebs on Security" aria-pressed="false">Krebs on Security <strong>1</strong></button><button class="source-count source-count-empty" type="button" data-source-filter="Threatpost" aria-pressed="false" aria-disabled="true" disabled>Threatpost <strong>0</strong></button></div>
-      <a href="./feed.xml">RSS feed</a>
+      <a class="feed-link" href="./feed.xml" aria-label="Open RSS feed with 30 latest articles">RSS feed <span class="feed-link-count">30 items</span></a>
     </section>
     <section class="operator-lanes" aria-label="Operator scan lanes">
       <article class="operator-lane" data-lane="Incident watch" data-lane-cue="SentryInsight: incident watch">

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -270,6 +270,8 @@ function renderSourceCoverage(newsItems, sourceNames = []) {
     return '';
   }
 
+  const feedItemLabel = newsItems.length === 1 ? '1 item' : `${newsItems.length} items`;
+  const feedArticleLabel = newsItems.length === 1 ? '1 latest article' : `${newsItems.length} latest articles`;
   const sourceCountItems = sourceCounts
     .map(({ source, count }) => {
       const emptyClass = count === 0 ? ' source-count-empty' : '';
@@ -281,7 +283,7 @@ function renderSourceCoverage(newsItems, sourceNames = []) {
   return `<section class="source-coverage" aria-label="RSS source coverage">
       <div class="source-coverage-label">RSS source coverage</div>
       <div class="source-counts">${sourceCountItems}</div>
-      <a href="./feed.xml">RSS feed</a>
+      <a class="feed-link" href="./feed.xml" aria-label="Open RSS feed with ${feedArticleLabel}">RSS feed <span class="feed-link-count">${feedItemLabel}</span></a>
     </section>`;
 }
 
@@ -529,6 +531,8 @@ function generateHTML(newsItems, options = {}) {
     .source-count strong { color: var(--accent); margin-left: 4px; }
     .source-coverage a { color: var(--accent); font-size: 0.9rem; font-weight: 600; text-decoration: none; }
     .source-coverage a:hover { text-decoration: underline; }
+    .feed-link { align-items: center; display: inline-flex; gap: 6px; }
+    .feed-link-count { background: var(--chip); border-radius: 999px; color: var(--muted); font-size: 12px; padding: 2px 8px; }
     .operator-lanes { display: grid; gap: 12px; grid-template-columns: repeat(3, minmax(0, 1fr)); margin-top: 14px; }
     .operator-lane { background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; display: grid; gap: 6px; padding: 12px; }
     .operator-lane-heading { font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -693,8 +693,22 @@ test('generateHTML renders escaped source coverage and RSS clarity', () => {
   assert.match(html, /<section class="source-coverage" aria-label="RSS source coverage">/);
   assert.match(html, /<button class="source-count" type="button" data-source-filter="Example &lt;Security&gt;" aria-pressed="false">Example &lt;Security&gt; <strong>2<\/strong><\/button>/);
   assert.match(html, /<button class="source-count" type="button" data-source-filter="Another Source" aria-pressed="false">Another Source <strong>1<\/strong><\/button>/);
-  assert.match(html, /<a href="\.\/feed\.xml">RSS feed<\/a>/);
+  assert.match(html, /<a class="feed-link" href="\.\/feed\.xml" aria-label="Open RSS feed with 3 latest articles">RSS feed <span class="feed-link-count">3 items<\/span><\/a>/);
   assert.doesNotMatch(html, /Example <Security>/);
+});
+
+test('generateHTML renders singular RSS item count for feed inspection', () => {
+  const html = generateHTML([
+    {
+      title: 'First story',
+      link: 'https://example.com/first',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Example Security',
+      summary: 'Story one.',
+    },
+  ], { generatedAt: new Date('2026-06-17T18:00:00.000Z') });
+
+  assert.match(html, /<a class="feed-link" href="\.\/feed\.xml" aria-label="Open RSS feed with 1 latest article">RSS feed <span class="feed-link-count">1 item<\/span><\/a>/);
 });
 
 test('generateHTML renders quiet configured feeds as inert source coverage chips', () => {


### PR DESCRIPTION
## Summary
- Show the generated RSS item count in the source coverage feed link.
- Keep the feed inspection affordance derived from the generated article set.
- Cover plural and singular feed item labels with renderer tests.

## Validation
- `npm test`
- `git diff --check`