### PR TITLE
Add compact digest legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,14 +67,16 @@
     .source-coverage a:hover { text-decoration: underline; }
     .feed-link { align-items: center; display: inline-flex; gap: 6px; }
     .feed-link-count { background: var(--chip); border-radius: 999px; color: var(--muted); font-size: 12px; padding: 2px 8px; }
-    .source-signal-legend { align-items: center; background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; display: flex; flex-wrap: wrap; gap: 10px 12px; margin-top: 12px; padding: 10px 12px; }
-    .source-signal-legend-label { color: var(--muted); font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
+    .digest-legend { background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; margin-top: 12px; padding: 10px 12px; }
+    .digest-legend-summary { color: var(--fg); cursor: pointer; font-size: 0.9rem; font-weight: 700; }
+    .digest-legend-summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+    .digest-legend-body { display: grid; gap: 10px; grid-template-columns: minmax(180px, 0.6fr) minmax(0, 1.4fr); margin-top: 10px; }
+    .digest-legend-group { align-content: start; display: grid; gap: 8px; min-width: 0; }
+    .digest-legend-heading { color: var(--muted); font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
     .source-signal-items { display: flex; flex: 1 1 260px; flex-wrap: wrap; gap: 8px; }
     .source-signal-chip { align-items: baseline; background: var(--chip); border-radius: 999px; display: inline-flex; gap: 6px; padding: 4px 10px; }
     .source-signal-name { color: var(--fg); font-size: 12px; font-weight: 700; }
     .source-signal-detail { color: var(--muted); font-size: 12px; }
-    .handoff-cue-legend { align-items: center; background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; display: flex; flex-wrap: wrap; gap: 10px 12px; margin-top: 12px; padding: 10px 12px; }
-    .handoff-cue-legend-label { color: var(--muted); font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
     .handoff-cue-legend-items { display: flex; flex: 1 1 260px; flex-wrap: wrap; gap: 8px; }
     .handoff-cue-legend-chip { align-items: baseline; background: var(--chip); border-radius: 999px; display: inline-flex; gap: 6px; padding: 4px 10px; }
     .handoff-cue-name { color: var(--fg); font-size: 12px; font-weight: 700; }
@@ -127,6 +129,7 @@
       .search { width: 100%; }
       .search input { min-width: 0; width: 100%; }
       .select, .btn { flex: 1 1 auto; }
+      .digest-legend-body { grid-template-columns: minmax(0, 1fr); }
       .operator-lanes { grid-template-columns: minmax(0, 1fr); }
       .news-container { grid-template-columns: minmax(0, 1fr); }
       .news-item { border-radius: 10px; }
@@ -187,14 +190,18 @@
     </div>
     <div class="stats" id="stats">Showing 30 of 30 articles from 4 sources • Last updated <time datetime="2026-06-24T01:00:43.975Z">6/24/2026, 1:00:43 AM</time></div>
     <div id="filterInsights" class="filter-insights" aria-live="polite"></div>
-    <section class="source-signal-legend" aria-label="Source signal legend">
-      <div class="source-signal-legend-label">Source signals</div>
+    <details class="digest-legend" aria-label="Digest legend">
+      <summary class="digest-legend-summary">Digest legend: source signals and handoff cues</summary>
+      <div class="digest-legend-body">
+        <div class="digest-legend-group source-signal-legend" aria-label="Source signal legend">
+      <div class="digest-legend-heading">Source signals</div>
       <div class="source-signal-items"><span class="source-signal-chip"><span class="source-signal-name">Industry media</span><span class="source-signal-detail">Security news reporting</span></span></div>
-    </section>
-    <section class="handoff-cue-legend" aria-label="Handoff cue legend">
-      <div class="handoff-cue-legend-label">Handoff cues</div>
+    </div><div class="digest-legend-group handoff-cue-legend" aria-label="Handoff cue legend">
+      <div class="digest-legend-heading">Handoff cues</div>
       <div class="handoff-cue-legend-items"><span class="handoff-cue-legend-chip"><span class="handoff-cue-name">SentryInsight: incident watch</span><span class="handoff-cue-detail">Potential incident or compromise follow-up</span></span><span class="handoff-cue-legend-chip"><span class="handoff-cue-name">SentryInsight: vuln triage</span><span class="handoff-cue-detail">Vulnerability or exploitation review</span></span><span class="handoff-cue-legend-chip"><span class="handoff-cue-name">SentryInsight: vendor watch</span><span class="handoff-cue-detail">Vendor or product-owner tracking</span></span><span class="handoff-cue-legend-chip"><span class="handoff-cue-name">SentryInsight: monitor</span><span class="handoff-cue-detail">Low-signal item worth monitoring</span></span></div>
-    </section>
+    </div>
+      </div>
+    </details>
     <section class="source-coverage" aria-label="RSS source coverage">
       <div class="source-coverage-label">RSS source coverage</div>
       <div class="source-counts"><button class="source-count" type="button" data-source-filter="Bleeping Computer" aria-pressed="false">Bleeping Computer <strong>15</strong></button><button class="source-count" type="button" data-source-filter="The Hacker News" aria-pressed="false">The Hacker News <strong>9</strong></button><button class="source-count" type="button" data-source-filter="Dark Reading" aria-pressed="false">Dark Reading <strong>5</strong></button><button class="source-count" type="button" data-source-filter="Krebs on Security" aria-pressed="false">Krebs on Security <strong>1</strong></button><button class="source-count source-count-empty" type="button" data-source-filter="Threatpost" aria-pressed="false" aria-disabled="true" disabled>Threatpost <strong>0</strong></button></div>

--- a/scripts/render-news-html.js
+++ b/scripts/render-news-html.js
@@ -336,10 +336,10 @@ function renderSourceSignalLegend(newsItems) {
     .map(({ label, detail }) => `<span class="source-signal-chip"><span class="source-signal-name">${escapeHtml(label)}</span><span class="source-signal-detail">${escapeHtml(detail)}</span></span>`)
     .join('');
 
-  return `<section class="source-signal-legend" aria-label="Source signal legend">
-      <div class="source-signal-legend-label">Source signals</div>
+  return `<div class="digest-legend-group source-signal-legend" aria-label="Source signal legend">
+      <div class="digest-legend-heading">Source signals</div>
       <div class="source-signal-items">${signalChips}</div>
-    </section>`;
+    </div>`;
 }
 
 function renderHandoffCueLegend(newsItems) {
@@ -352,10 +352,26 @@ function renderHandoffCueLegend(newsItems) {
     .map(({ label, detail }) => `<span class="handoff-cue-legend-chip"><span class="handoff-cue-name">${escapeHtml(label)}</span><span class="handoff-cue-detail">${escapeHtml(detail)}</span></span>`)
     .join('');
 
-  return `<section class="handoff-cue-legend" aria-label="Handoff cue legend">
-      <div class="handoff-cue-legend-label">Handoff cues</div>
+  return `<div class="digest-legend-group handoff-cue-legend" aria-label="Handoff cue legend">
+      <div class="digest-legend-heading">Handoff cues</div>
       <div class="handoff-cue-legend-items">${cueChips}</div>
-    </section>`;
+    </div>`;
+}
+
+function renderDigestLegend(newsItems) {
+  const sourceSignalLegend = renderSourceSignalLegend(newsItems);
+  const handoffCueLegend = renderHandoffCueLegend(newsItems);
+  const groups = [sourceSignalLegend, handoffCueLegend].filter(Boolean).join('');
+  if (!groups) {
+    return '';
+  }
+
+  return `<details class="digest-legend" aria-label="Digest legend">
+      <summary class="digest-legend-summary">Digest legend: source signals and handoff cues</summary>
+      <div class="digest-legend-body">
+        ${groups}
+      </div>
+    </details>`;
 }
 
 function renderOperatorLanes(newsItems) {
@@ -530,8 +546,7 @@ function generateHTML(newsItems, options = {}) {
   const now = new Date(generatedAt);
   const nowIso = now.toISOString();
   const sourceCoverage = renderSourceCoverage(newsItems, sourceNames);
-  const sourceSignalLegend = renderSourceSignalLegend(newsItems);
-  const handoffCueLegend = renderHandoffCueLegend(newsItems);
+  const digestLegend = renderDigestLegend(newsItems);
   const operatorLanes = renderOperatorLanes(newsItems);
   const articleCards = newsItems.length > 0
     ? newsItems.map((article, index) => renderArticleCard(article, index, generatedAt)).join('')
@@ -606,14 +621,16 @@ function generateHTML(newsItems, options = {}) {
     .source-coverage a:hover { text-decoration: underline; }
     .feed-link { align-items: center; display: inline-flex; gap: 6px; }
     .feed-link-count { background: var(--chip); border-radius: 999px; color: var(--muted); font-size: 12px; padding: 2px 8px; }
-    .source-signal-legend { align-items: center; background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; display: flex; flex-wrap: wrap; gap: 10px 12px; margin-top: 12px; padding: 10px 12px; }
-    .source-signal-legend-label { color: var(--muted); font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
+    .digest-legend { background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; margin-top: 12px; padding: 10px 12px; }
+    .digest-legend-summary { color: var(--fg); cursor: pointer; font-size: 0.9rem; font-weight: 700; }
+    .digest-legend-summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+    .digest-legend-body { display: grid; gap: 10px; grid-template-columns: minmax(180px, 0.6fr) minmax(0, 1.4fr); margin-top: 10px; }
+    .digest-legend-group { align-content: start; display: grid; gap: 8px; min-width: 0; }
+    .digest-legend-heading { color: var(--muted); font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
     .source-signal-items { display: flex; flex: 1 1 260px; flex-wrap: wrap; gap: 8px; }
     .source-signal-chip { align-items: baseline; background: var(--chip); border-radius: 999px; display: inline-flex; gap: 6px; padding: 4px 10px; }
     .source-signal-name { color: var(--fg); font-size: 12px; font-weight: 700; }
     .source-signal-detail { color: var(--muted); font-size: 12px; }
-    .handoff-cue-legend { align-items: center; background: var(--card); border: 1px solid var(--card-border); border-radius: 10px; display: flex; flex-wrap: wrap; gap: 10px 12px; margin-top: 12px; padding: 10px 12px; }
-    .handoff-cue-legend-label { color: var(--muted); font-size: 0.82rem; font-weight: 700; text-transform: uppercase; }
     .handoff-cue-legend-items { display: flex; flex: 1 1 260px; flex-wrap: wrap; gap: 8px; }
     .handoff-cue-legend-chip { align-items: baseline; background: var(--chip); border-radius: 999px; display: inline-flex; gap: 6px; padding: 4px 10px; }
     .handoff-cue-name { color: var(--fg); font-size: 12px; font-weight: 700; }
@@ -666,6 +683,7 @@ function generateHTML(newsItems, options = {}) {
       .search { width: 100%; }
       .search input { min-width: 0; width: 100%; }
       .select, .btn { flex: 1 1 auto; }
+      .digest-legend-body { grid-template-columns: minmax(0, 1fr); }
       .operator-lanes { grid-template-columns: minmax(0, 1fr); }
       .news-container { grid-template-columns: minmax(0, 1fr); }
       .news-item { border-radius: 10px; }
@@ -726,8 +744,7 @@ function generateHTML(newsItems, options = {}) {
     </div>
     <div class="stats" id="stats">Showing ${totalItems} of ${totalItems} articles from ${uniqueSources.length} sources • Last updated <time datetime="${nowIso}">${now.toLocaleString()}</time></div>
     <div id="filterInsights" class="filter-insights" aria-live="polite"></div>
-    ${sourceSignalLegend}
-    ${handoffCueLegend}
+    ${digestLegend}
     ${sourceCoverage}
     ${operatorLanes}
     <div id="emptyFilteredState" class="empty-filtered" hidden>No articles match the current filters.</div>

--- a/test/fetch-news.test.js
+++ b/test/fetch-news.test.js
@@ -308,6 +308,35 @@ test('generateHTML renders escaped downstream handoff cues on article cards', ()
   assert.match(html, /<span class="handoff-cue">GRCInsight: governance watch<\/span>/);
 });
 
+test('generateHTML groups legend explanations into a compact digest legend', () => {
+  const html = generateHTML([
+    {
+      title: 'Microsoft Exchange zero-day exploited in data breach response',
+      link: 'https://security.example.com/microsoft-exchange-zero-day',
+      date: new Date('2026-06-17T18:00:00.000Z'),
+      source: 'Microsoft',
+      summary: 'SEC filings mention incident response, active exploitation, and stolen credentials.',
+    },
+    {
+      title: 'Security news roundup',
+      link: 'https://www.bleepingcomputer.com/news/security/example/',
+      date: new Date('2026-06-17T16:00:00.000Z'),
+      source: 'Bleeping Computer',
+      summary: 'Industry reporting on security activity.',
+    },
+  ]);
+
+  assert.match(html, /<details class="digest-legend" aria-label="Digest legend">/);
+  assert.match(html, /<summary class="digest-legend-summary">Digest legend: source signals and handoff cues<\/summary>/);
+  assert.match(html, /<div class="digest-legend-body">/);
+  assert.match(html, /<div class="digest-legend-group source-signal-legend" aria-label="Source signal legend">/);
+  assert.match(html, /<div class="digest-legend-group handoff-cue-legend" aria-label="Handoff cue legend">/);
+  assert.match(html, /<div class="digest-legend-heading">Source signals<\/div>/);
+  assert.match(html, /<div class="digest-legend-heading">Handoff cues<\/div>/);
+  assert.doesNotMatch(html, /<section class="source-signal-legend" aria-label="Source signal legend">/);
+  assert.doesNotMatch(html, /<section class="handoff-cue-legend" aria-label="Handoff cue legend">/);
+});
+
 test('generateHTML renders a handoff cue legend for present cues', () => {
   const html = generateHTML([
     {
@@ -326,8 +355,8 @@ test('generateHTML renders a handoff cue legend for present cues', () => {
     },
   ]);
 
-  assert.match(html, /<section class="handoff-cue-legend" aria-label="Handoff cue legend">/);
-  assert.match(html, /<div class="handoff-cue-legend-label">Handoff cues<\/div>/);
+  assert.match(html, /<div class="digest-legend-group handoff-cue-legend" aria-label="Handoff cue legend">/);
+  assert.match(html, /<div class="digest-legend-heading">Handoff cues<\/div>/);
   assert.match(html, /<span class="handoff-cue-name">SentryInsight: incident watch<\/span><span class="handoff-cue-detail">Potential incident or compromise follow-up<\/span>/);
   assert.match(html, /<span class="handoff-cue-name">SentryInsight: vuln triage<\/span><span class="handoff-cue-detail">Vulnerability or exploitation review<\/span>/);
   assert.match(html, /<span class="handoff-cue-name">SentryInsight: vendor watch<\/span><span class="handoff-cue-detail">Vendor or product-owner tracking<\/span>/);
@@ -347,7 +376,7 @@ test('generateHTML omits absent handoff cue legend entries', () => {
     },
   ]);
 
-  assert.match(html, /<section class="handoff-cue-legend" aria-label="Handoff cue legend">/);
+  assert.match(html, /<div class="digest-legend-group handoff-cue-legend" aria-label="Handoff cue legend">/);
   assert.match(html, /<span class="handoff-cue-name">SentryInsight: monitor<\/span>/);
   assert.doesNotMatch(html, /Potential incident or compromise follow-up/);
   assert.doesNotMatch(html, /Vulnerability or exploitation review/);
@@ -387,8 +416,8 @@ test('generateHTML renders a source signal legend for present classifications', 
     },
   ]);
 
-  assert.match(html, /<section class="source-signal-legend" aria-label="Source signal legend">/);
-  assert.match(html, /<div class="source-signal-legend-label">Source signals<\/div>/);
+  assert.match(html, /<div class="digest-legend-group source-signal-legend" aria-label="Source signal legend">/);
+  assert.match(html, /<div class="digest-legend-heading">Source signals<\/div>/);
   assert.match(html, /<span class="source-signal-name">Vendor advisory<\/span><span class="source-signal-detail">Vendor or product-owner guidance<\/span>/);
   assert.match(html, /<span class="source-signal-name">Research team<\/span><span class="source-signal-detail">Threat research or lab analysis<\/span>/);
   assert.match(html, /<span class="source-signal-name">Industry media<\/span><span class="source-signal-detail">Security news reporting<\/span>/);
@@ -407,7 +436,7 @@ test('generateHTML omits absent source signal legend entries', () => {
     },
   ]);
 
-  assert.match(html, /<section class="source-signal-legend" aria-label="Source signal legend">/);
+  assert.match(html, /<div class="digest-legend-group source-signal-legend" aria-label="Source signal legend">/);
   assert.match(html, /<span class="source-signal-name">Industry media<\/span>/);
   assert.doesNotMatch(html, /Vendor or product-owner guidance/);
   assert.doesNotMatch(html, /Threat research or lab analysis/);


### PR DESCRIPTION
## Summary
- Group source-signal and handoff-cue explanations into one generated digest legend.
- Use a native disclosure so the digest stays scannable while explanation details remain available.
- Cover the grouped legend structure with renderer tests.

## Validation
- `npm test`
- `git diff --check`